### PR TITLE
Implement automatic driver (ODBC) and provider (OLE DB) inference and detection

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -14,8 +14,9 @@
     <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
     <SystemCollectionsImmutableVersion>1.7.0</SystemCollectionsImmutableVersion>
     <SystemComponentModelAnnotationsVersion>4.7.0</SystemComponentModelAnnotationsVersion>
-    <SystemDataOleDbVersion>5.0.0-preview.3.20171.3</SystemDataOleDbVersion>
-    <SystemDataOdbcVersion>5.0.0-preview.3.20171.3</SystemDataOdbcVersion>
+    <MicrosoftWin32Registry>4.7.0</MicrosoftWin32Registry>
+    <SystemDataOleDbVersion>5.0.0-preview.3.20178.1</SystemDataOleDbVersion>
+    <SystemDataOdbcVersion>5.0.0-preview.3.20178.1</SystemDataOdbcVersion>
   </PropertyGroup>
   <!-- System.Data.Jet -->
   <PropertyGroup>

--- a/src/EFCore.Jet/Extensions/JetDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.Jet/Extensions/JetDbContextOptionsBuilderExtensions.cs
@@ -24,147 +24,166 @@ namespace Microsoft.EntityFrameworkCore
         ///     Configures the context to connect to a Microsoft Jet database.
         /// </summary>
         /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
-        /// <param name="connectionString"> The connection string of the database to connect to. The underlying data
-        /// access provider (ODBC or OLE DB) will be inferred from the style of this connection string. </param>
+        /// <param name="fileNameOrConnectionString"> The file name or connection string of the database to connect to.
+        /// If just a file name is supplied, the default data access provider type as defined by
+        /// `JetConfiguration.DefaultDataAccessProviderType` is being used. If a connection string is supplied, the
+        /// underlying data access provider (ODBC or OLE DB) will be inferred from the style of the connection string.
+        /// In case the connection string does not specify an Access driver (ODBC) or ACE/Jet provider (OLE DB), the
+        /// highest version of all compatible installed ones is being used. </param>
         /// <param name="jetOptionsAction">An optional action to allow additional Jet specific configuration.</param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder<TContext> UseJet<TContext>(
             [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
-            [NotNull] string connectionString,
+            [NotNull] string fileNameOrConnectionString,
             [CanBeNull] Action<JetDbContextOptionsBuilder> jetOptionsAction = null)
             where TContext : DbContext
-            => (DbContextOptionsBuilder<TContext>) UseJet((DbContextOptionsBuilder) optionsBuilder, connectionString, jetOptionsAction);
+            => (DbContextOptionsBuilder<TContext>) UseJet((DbContextOptionsBuilder) optionsBuilder, fileNameOrConnectionString, jetOptionsAction);
 
         /// <summary>
         ///     Configures the context to connect to a Microsoft Jet database.
         /// </summary>
         /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
-        /// <param name="connectionString"> The connection string of the database to connect to. The underlying data
-        /// access provider (ODBC or OLE DB) will be inferred from the style of this connection string. </param>
+        /// <param name="fileNameOrConnectionString"> The file name or connection string of the database to connect to.
+        /// If just a file name is supplied, the default data access provider type as defined by
+        /// `JetConfiguration.DefaultDataAccessProviderType` is being used. If a connection string is supplied, the
+        /// underlying data access provider (ODBC or OLE DB) will be inferred from the style of the connection string.
+        /// In case the connection string does not specify an Access driver (ODBC) or ACE/Jet provider (OLE DB), the
+        /// highest version of all compatible installed ones is being used. </param>
         /// <param name="jetOptionsAction">An optional action to allow additional Jet specific configuration.</param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder UseJet(
             [NotNull] this DbContextOptionsBuilder optionsBuilder,
-            [NotNull] string connectionString,
+            [NotNull] string fileNameOrConnectionString,
             [CanBeNull] Action<JetDbContextOptionsBuilder> jetOptionsAction = null)
         {
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
-            Check.NotEmpty(connectionString, nameof(connectionString));
+            Check.NotEmpty(fileNameOrConnectionString, nameof(fileNameOrConnectionString));
 
-            return UseJetCore(optionsBuilder, connectionString, null, JetConnection.GetDataAccessProviderType(connectionString), jetOptionsAction);
+            return UseJetCore(optionsBuilder, fileNameOrConnectionString, null, null, jetOptionsAction);
         }
 
         /// <summary>
         ///     Configures the context to connect to a Microsoft Jet database.
         /// </summary>
         /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
-        /// <param name="connectionString"> The connection string of the database to connect to. </param>
+        /// <param name="fileNameOrConnectionString"> The file name or connection string of the database to connect to.
         /// <param name="dataAccessProviderFactory">An `OdbcFactory` or `OleDbFactory` object to be used for all
         /// data access operations by the Jet connection.</param>
         /// <param name="jetOptionsAction">An optional action to allow additional Jet specific configuration.</param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder<TContext> UseJet<TContext>(
             [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
-            [NotNull] string connectionString,
+            [NotNull] string fileNameOrConnectionString,
             [NotNull] DbProviderFactory dataAccessProviderFactory,
             [CanBeNull] Action<JetDbContextOptionsBuilder> jetOptionsAction = null)
             where TContext : DbContext
         {
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
-            Check.NotEmpty(connectionString, nameof(connectionString));
+            Check.NotEmpty(fileNameOrConnectionString, nameof(fileNameOrConnectionString));
             Check.NotNull(dataAccessProviderFactory, nameof(dataAccessProviderFactory));
 
-            return (DbContextOptionsBuilder<TContext>) UseJet((DbContextOptionsBuilder) optionsBuilder, connectionString, dataAccessProviderFactory, jetOptionsAction);
+            return (DbContextOptionsBuilder<TContext>) UseJet((DbContextOptionsBuilder) optionsBuilder, fileNameOrConnectionString, dataAccessProviderFactory, jetOptionsAction);
         }
 
         /// <summary>
         ///     Configures the context to connect to a Microsoft Jet database.
         /// </summary>
         /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
-        /// <param name="connectionString"> The connection string of the database to connect to. </param>
+        /// <param name="fileNameOrConnectionString"> The file name or connection string of the database to connect to.
         /// <param name="dataAccessProviderFactory">An `OdbcFactory` or `OleDbFactory` object to be used for all
         /// data access operations by the Jet connection.</param>
         /// <param name="jetOptionsAction">An optional action to allow additional Jet specific configuration.</param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder UseJet(
             [NotNull] this DbContextOptionsBuilder optionsBuilder,
-            [NotNull] string connectionString,
+            [NotNull] string fileNameOrConnectionString,
             [NotNull] DbProviderFactory dataAccessProviderFactory,
             [CanBeNull] Action<JetDbContextOptionsBuilder> jetOptionsAction = null)
         {
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
-            Check.NotEmpty(connectionString, nameof(connectionString));
+            Check.NotEmpty(fileNameOrConnectionString, nameof(fileNameOrConnectionString));
             Check.NotNull(dataAccessProviderFactory, nameof(dataAccessProviderFactory));
 
-            return UseJetCore(optionsBuilder, connectionString, dataAccessProviderFactory, null, jetOptionsAction);
+            return UseJetCore(optionsBuilder, fileNameOrConnectionString, dataAccessProviderFactory, null, jetOptionsAction);
         }
 
         /// <summary>
         ///     Configures the context to connect to a Microsoft Jet database.
         /// </summary>
         /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
-        /// <param name="connectionString"> The connection string of the database to connect to. </param>
+        /// <param name="fileNameOrConnectionString"> The file name or connection string of the database to connect to.
         /// <param name="dataAccessProviderType">The type of the data access provider (`Odbc` or `OleDb`) to be used for all
         /// data access operations by the Jet connection.</param>
         /// <param name="jetOptionsAction">An optional action to allow additional Jet specific configuration.</param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder<TContext> UseJet<TContext>(
             [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
-            [NotNull] string connectionString,
+            [NotNull] string fileNameOrConnectionString,
             DataAccessProviderType dataAccessProviderType,
             [CanBeNull] Action<JetDbContextOptionsBuilder> jetOptionsAction = null)
             where TContext : DbContext
         {
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
-            Check.NotEmpty(connectionString, nameof(connectionString));
+            Check.NotEmpty(fileNameOrConnectionString, nameof(fileNameOrConnectionString));
 
-            return (DbContextOptionsBuilder<TContext>) UseJet((DbContextOptionsBuilder)optionsBuilder, connectionString, dataAccessProviderType, jetOptionsAction);
+            return (DbContextOptionsBuilder<TContext>) UseJet((DbContextOptionsBuilder)optionsBuilder, fileNameOrConnectionString, dataAccessProviderType, jetOptionsAction);
         }
 
         /// <summary>
         ///     Configures the context to connect to a Microsoft Jet database.
         /// </summary>
         /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
-        /// <param name="connectionString"> The connection string of the database to connect to. </param>
+        /// <param name="fileNameOrConnectionString"> The file name or connection string of the database to connect to.
         /// <param name="dataAccessProviderType">The type of the data access provider (`Odbc` or `OleDb`) to be used for all
         /// data access operations by the Jet connection.</param>
         /// <param name="jetOptionsAction">An optional action to allow additional Jet specific configuration.</param>
         /// <returns> The options builder so that further configuration can be chained. </returns>
         public static DbContextOptionsBuilder UseJet(
             [NotNull] this DbContextOptionsBuilder optionsBuilder,
-            [NotNull] string connectionString,
+            [NotNull] string fileNameOrConnectionString,
             DataAccessProviderType dataAccessProviderType,
             [CanBeNull] Action<JetDbContextOptionsBuilder> jetOptionsAction = null)
         {
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
-            Check.NotEmpty(connectionString, nameof(connectionString));
+            Check.NotEmpty(fileNameOrConnectionString, nameof(fileNameOrConnectionString));
 
-            return UseJetCore(optionsBuilder, connectionString, null, dataAccessProviderType, jetOptionsAction);
+            return UseJetCore(optionsBuilder, fileNameOrConnectionString, null, dataAccessProviderType, jetOptionsAction);
         }
 
         internal static DbContextOptionsBuilder UseJetWithoutPredefinedDataAccessProvider(
             [NotNull] this DbContextOptionsBuilder optionsBuilder,
-            [NotNull] string connectionString,
+            [NotNull] string fileNameOrConnectionString,
             [CanBeNull] Action<JetDbContextOptionsBuilder> jetOptionsAction = null)
-            => UseJetCore(optionsBuilder, connectionString, null, null, jetOptionsAction);
+            => UseJetCore(optionsBuilder, fileNameOrConnectionString, null, null, jetOptionsAction);
 
         private static DbContextOptionsBuilder UseJetCore(
             [NotNull] DbContextOptionsBuilder optionsBuilder,
-            [NotNull] string connectionString,
+            [NotNull] string fileNameOrConnectionString,
             [CanBeNull] DbProviderFactory dataAccessProviderFactory,
             [CanBeNull] DataAccessProviderType? dataAccessProviderType,
             Action<JetDbContextOptionsBuilder> jetOptionsAction)
         {
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
-            Check.NotEmpty(connectionString, nameof(connectionString));
+            Check.NotEmpty(fileNameOrConnectionString, nameof(fileNameOrConnectionString));
 
             if (dataAccessProviderFactory == null && dataAccessProviderType == null)
             {
-                throw new ArgumentException($"One of the parameters {nameof(dataAccessProviderFactory)} and {nameof(dataAccessProviderType)} must not be null.");
+                if (JetConnection.IsConnectionString(fileNameOrConnectionString))
+                {
+                    dataAccessProviderType = JetConnection.GetDataAccessProviderType(fileNameOrConnectionString);
+                }
+                else if (JetConnection.IsFileName(fileNameOrConnectionString))
+                {
+                    dataAccessProviderType = JetConfiguration.DefaultDataAccessProviderType;
+                }
+                else
+                {
+                    throw new ArgumentException($"Either {nameof(dataAccessProviderFactory)} or {nameof(dataAccessProviderType)} must not be null, or a file name must be specified for {nameof(fileNameOrConnectionString)}.");
+                }
             }
 
             var extension = (JetOptionsExtension) GetOrCreateExtension(optionsBuilder)
-                .WithConnectionString(connectionString);
+                .WithConnectionString(fileNameOrConnectionString);
 
             extension = extension.WithDataAccessProviderFactory(
                 dataAccessProviderFactory ?? JetFactory.Instance.GetDataAccessProviderFactory(dataAccessProviderType.Value));
@@ -231,7 +250,22 @@ namespace Microsoft.EntityFrameworkCore
 
             if (jetConnection.DataAccessProviderFactory == null)
             {
-                var dataAccessProviderType = JetConnection.GetDataAccessProviderType(jetConnection.ConnectionString);
+                var fileNameOrConnectionString = jetConnection.ConnectionString;
+                DataAccessProviderType dataAccessProviderType;
+                
+                if (JetConnection.IsConnectionString(fileNameOrConnectionString))
+                {
+                    dataAccessProviderType = JetConnection.GetDataAccessProviderType(fileNameOrConnectionString);
+                }
+                else if (JetConnection.IsFileName(fileNameOrConnectionString))
+                {
+                    dataAccessProviderType = JetConfiguration.DefaultDataAccessProviderType;
+                }
+                else
+                {
+                    throw new ArgumentException($"The data access provider type could not be inferred from the connections {nameof(JetConnection.DataAccessProviderFactory)} or {nameof(JetConnection.ConnectionString)} property and the {nameof(JetConnection.ConnectionString)} property is not a valid file name either.");
+                }
+
                 jetConnection.DataAccessProviderFactory = JetFactory.Instance.GetDataAccessProviderFactory(dataAccessProviderType);
                 jetConnection.Freeze();
             }

--- a/src/EFCore.Jet/Migrations/JetMigrationsSqlGenerator.cs
+++ b/src/EFCore.Jet/Migrations/JetMigrationsSqlGenerator.cs
@@ -364,6 +364,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
+            // CHECK: Rename table operations require extensions like ADOX or DAO.
+            //       A native way to do this would be to:
+            //           1. CREATE TABLE `destination table`
+            //           2. INSERT INTO ... SELECT ... FROM
+            //           3. DROP TABLE `source table`
+            //           4. Recrete indices and references.
             builder.Append("RENAME TABLE ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
                 .Append(" TO ")

--- a/src/EFCore.Jet/Scaffolding/Internal/JetDatabaseModelFactory.cs
+++ b/src/EFCore.Jet/Scaffolding/Internal/JetDatabaseModelFactory.cs
@@ -34,7 +34,7 @@ namespace EntityFrameworkCore.Jet.Scaffolding.Internal
         private Dictionary<string, DatabaseColumn> _tableColumns;
 
         private static string ObjectKey([NotNull] string name)
-            => "[" + name + "]";
+            => "`" + name + "`";
         
         private static string TableKey(DatabaseTable table)
             => TableKey(table.Name);
@@ -48,6 +48,7 @@ namespace EntityFrameworkCore.Jet.Scaffolding.Internal
         private static readonly List<string> _tablePatterns = new List<string>
         {
             "{table}",
+            "`{table}`",
             "[{table}]"
         };
 

--- a/src/System.Data.Jet/AdoxWrapper.cs
+++ b/src/System.Data.Jet/AdoxWrapper.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Data.Jet.JetStoreSchemaDefinition;
 
 namespace System.Data.Jet
 {
@@ -61,8 +62,10 @@ namespace System.Data.Jet
             }
         }
         
-        public static string CreateEmptyDatabase(string fileName, DbProviderFactory dataAccessProviderFactory)
+        public static string CreateEmptyDatabase(string fileNameOrConnectionString, DbProviderFactory dataAccessProviderFactory)
         {
+            var fileName = JetStoreDatabaseHandling.ExpandFileName(JetStoreDatabaseHandling.ExtractFileNameFromConnectionString(fileNameOrConnectionString));
+            
             string connectionString = null;
             using var catalog = GetCatalogInstance();
             
@@ -77,7 +80,7 @@ namespace System.Data.Jet
             }
             catch (Exception e)
             {
-                throw new Exception("Cannot create database using the specified connection string: " + connectionString, e);
+                throw new Exception($"Cannot create database \"{fileName}\" using ADOX with the following connection string: " + connectionString, e);
             }
 
             try
@@ -108,7 +111,7 @@ CREATE UNIQUE INDEX `ParentIdName` ON `MSysAccessStorage` (`ParentId`, `Name`);"
             }
             catch (Exception e)
             {
-                throw new Exception("Cannot create database using the specified connection string.", e);
+                throw new Exception($"Cannot setup the newly created database \"{fileName}\" using {Enum.GetName(typeof(DataAccessProviderType), JetConnection.GetDataAccessProviderType(dataAccessProviderFactory))} with the following connection string: " + connectionString, e);
             }
 
             try

--- a/src/System.Data.Jet/AdoxWrapper.cs
+++ b/src/System.Data.Jet/AdoxWrapper.cs
@@ -24,6 +24,8 @@ namespace System.Data.Jet
             }
             catch (Exception e)
             {
+                // TODO: Try interating over the _Tables collection instead of using Item["TableName"].
+                
                 throw new Exception("Cannot rename table", e);
             }
             finally
@@ -48,7 +50,8 @@ namespace System.Data.Jet
             try
             {
                 using var tables = catalog.Tables;
-                using var columns = tables[tableName].Columns;
+                using var table = tables[tableName];
+                using var columns = table.Columns;
                 using var column = columns[columnName];
                 column.Name = newColumnName;
             }
@@ -92,8 +95,7 @@ namespace System.Data.Jet
                 connection.DataAccessProviderFactory = dataAccessProviderFactory;
                 connection.Open();
                 
-                string sql = @"
-CREATE TABLE `MSysAccessStorage` (
+                var sql = @"CREATE TABLE `MSysAccessStorage` (
     `DateCreate` DATETIME NULL,
     `DateUpdate` DATETIME NULL,
     `Id` COUNTER NOT NULL,
@@ -136,9 +138,9 @@ CREATE UNIQUE INDEX `ParentIdName` ON `MSysAccessStorage` (`ParentId`, `Name`);"
 
             try
             {
-                using dynamic cnn = new ComObject("ADODB.Connection");
-                cnn.Open(connectionString);
-                catalog.ActiveConnection = cnn;
+                using dynamic connection = new ComObject("ADODB.Connection");
+                connection.Open(connectionString);
+                catalog.ActiveConnection = connection;
             }
             catch (Exception e)
             {

--- a/src/System.Data.Jet/ComObject.cs
+++ b/src/System.Data.Jet/ComObject.cs
@@ -110,7 +110,7 @@ namespace System.Data.Jet
         
         public void Dispose()
         {
-            // The RCW is a .NET object and cannot be released from the finalizer anymore,
+            // The RCW is a .NET object and cannot be released from the finalizer,
             // because it might not exist anymore.
             if (_instance != null)
             {

--- a/src/System.Data.Jet/DbConnectionStringBuilderExtensions.cs
+++ b/src/System.Data.Jet/DbConnectionStringBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace System.Data.Jet
             }
             else if (IsOdbc(builder))
             {
-                builder["driver"] = Regex.Replace(value.Trim(), @"^(?<!\{).*(?!\})$", @"{$1}", RegexOptions.IgnoreCase);
+                builder["driver"] = Regex.Replace(value.Trim(), @"^(?<!\{)(.*)(?!\})$", @"{$1}", RegexOptions.IgnoreCase);
             }
             else
                 throw new InvalidOperationException("This extension method only supports OdbcConnectionStringBuilder and OleDbConnectionStringBuilder.");

--- a/src/System.Data.Jet/InnerConnectionFactory.cs
+++ b/src/System.Data.Jet/InnerConnectionFactory.cs
@@ -5,7 +5,7 @@ namespace System.Data.Jet
 {
     class InnerConnectionFactory : IDisposable
     {
-        public static InnerConnectionFactory Instance = new InnerConnectionFactory();
+        public static readonly InnerConnectionFactory Instance = new InnerConnectionFactory();
 
         private InnerConnectionFactory()
         {

--- a/src/System.Data.Jet/JetCommand.cs
+++ b/src/System.Data.Jet/JetCommand.cs
@@ -19,7 +19,7 @@ namespace System.Data.Jet
         private int? _rowCount;
 
         private static readonly Regex _skipRegularExpression = new Regex(@"\bskip\s(?<stringSkipCount>@.*)\b", RegexOptions.IgnoreCase);
-        private static readonly Regex _selectRowCountRegularExpression = new Regex(@"^\s*select\s*@@rowcount\s*[;]?\s*$", RegexOptions.IgnoreCase);
+        private static readonly Regex _selectRowCountRegularExpression = new Regex(@"^\s*select\s*@@rowcount\s*;?\s*$", RegexOptions.IgnoreCase);
         private static readonly Regex _ifStatementRegex = new Regex(@"^\s*if\s*(?<not>not)?\s*exists\s*\((?<sqlCheckCommand>.+)\)\s*then\s*(?<sqlCommand>.*)$", RegexOptions.IgnoreCase);
 
         protected JetCommand(JetCommand source)

--- a/src/System.Data.Jet/JetConfiguration.cs
+++ b/src/System.Data.Jet/JetConfiguration.cs
@@ -1,8 +1,4 @@
-﻿using System.Data.Common;
-
-// ReSharper disable InconsistentNaming
-
-namespace System.Data.Jet
+﻿namespace System.Data.Jet
 {
     /// <summary>
     /// Jet configuration
@@ -12,10 +8,11 @@ namespace System.Data.Jet
         /// <summary>
         /// The time span offset (Jet does not support timespans)
         /// </summary>
-        public static DateTime TimeSpanOffset = new DateTime(1899, 12, 30);
+        public static DateTime TimeSpanOffset { get; set; } = new DateTime(1899, 12, 30);
 
         private static object _integerNullValue = Int32.MinValue;
 
+        // CHECK: Replace with Nullable<Int32>
         /// <summary>
         /// Gets or sets the integer null value returned by queries. This should solve a Jet issue
         /// that if I do a UNION ALL of null, int and null the Jet raises an error
@@ -25,7 +22,7 @@ namespace System.Data.Jet
         /// </value>
         public static object IntegerNullValue
         {
-            get { return _integerNullValue; }
+            get => _integerNullValue;
             set
             {
                 if (!(value is int) && value != null)
@@ -33,13 +30,8 @@ namespace System.Data.Jet
                 _integerNullValue = value;
             }
         }
-
-        // "Microsoft.ACE.OLEDB.12.0" should have the fewest problems of all versions, as it supports 32 Bit and 64 Bit,
-        // does not throw an AccessViolationException when connecting through OLE DB without connection pooling enabled,
-        // has the highest backwards compatibility level of all recent releases and can freely be downloaded from
-        // Microsoft as "Microsoft Access Database Engine 2010 Redistributable".
-        public static string OleDbDefaultProvider = "Microsoft.ACE.OLEDB.12.0";
-        public static string OdbcDefaultProvider = "Microsoft Access Driver (*.mdb, *.accdb)";
+        
+        public static DataAccessProviderType DefaultDataAccessProviderType { get; set; } = DataAccessProviderType.OleDb; 
         
         // The SQL statement
         //
@@ -63,7 +55,7 @@ namespace System.Data.Jet
         /// <summary>
         /// The DUAL table or query
         /// </summary>
-        public static string DUAL = DUALForAccdb;
+        public static string DUAL { get; set; } = DUALForAccdb;
 
         /// <summary>
         /// The dual table for accdb
@@ -81,7 +73,7 @@ namespace System.Data.Jet
         /// <value>
         ///   <c>true</c> to show SQL statements; otherwise, <c>false</c>.
         /// </value>
-        public static bool ShowSqlStatements = false;
+        public static bool ShowSqlStatements { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether the connection pooling should be used
@@ -89,6 +81,6 @@ namespace System.Data.Jet
         /// <value>
         /// <c>true</c> to use the connection pooling; otherwise, <c>false</c>.
         /// </value>
-        public static bool UseConnectionPooling = false;
+        public static bool UseConnectionPooling { get; set; } = false;
     }
 }

--- a/src/System.Data.Jet/JetConnection.cs
+++ b/src/System.Data.Jet/JetConnection.cs
@@ -489,6 +489,9 @@ namespace System.Data.Jet
         public void CreateEmptyDatabase()
             => CreateEmptyDatabase(DataSource, DataAccessProviderFactory);
 
+        // TODO: Use the `CREATE_DB` connection string option instead of calling ADOX when using ODBC, to create
+        //       a new database file.
+        //       Alternatively, use DAO in conjunction with ODBC.
         public static string CreateEmptyDatabase(string fileNameOrConnectionString, DbProviderFactory dataAccessProviderFactory)
             => AdoxWrapper.CreateEmptyDatabase(fileNameOrConnectionString, dataAccessProviderFactory);
 

--- a/src/System.Data.Jet/JetConnection.cs
+++ b/src/System.Data.Jet/JetConnection.cs
@@ -417,8 +417,7 @@ namespace System.Data.Jet
 
             try
             {
-                var sqlFormat = "select count(*) from [{0}] where 1=2";
-                CreateCommand(string.Format(sqlFormat, tableName))
+                CreateCommand($"select count(*) from `{tableName}` where 1=2")
                     .ExecuteNonQuery();
                 tableExists = true;
             }

--- a/src/System.Data.Jet/JetConnection.cs
+++ b/src/System.Data.Jet/JetConnection.cs
@@ -80,7 +80,7 @@ namespace System.Data.Jet
         /// <exception cref="InvalidOperationException">This property can only be set as long as the connection is closed.</exception>
         public DbProviderFactory DataAccessProviderFactory
         {
-            get => JetFactory.InnerFactory;
+            get => JetFactory?.InnerFactory;
             set
             {
                 if (value == null)

--- a/src/System.Data.Jet/JetConnection.cs
+++ b/src/System.Data.Jet/JetConnection.cs
@@ -351,6 +351,16 @@ namespace System.Data.Jet
                 connectionStringBuilder.SetProvider(provider);
                 connectionString = connectionStringBuilder.ToString();
             }
+            
+            // Enable ExtendedAnsiSQL when using ODBC to support ODBC 4.0 statements (like CREATE VIEW).
+            if (dataAccessProviderType == DataAccessProviderType.Odbc)
+            {
+                if (!connectionStringBuilder.ContainsKey("ExtendedAnsiSQL"))
+                {
+                    connectionStringBuilder["ExtendedAnsiSQL"] = 1;
+                    connectionString = connectionStringBuilder.ToString();
+                }
+            }
 
             DataAccessProviderFactory ??= dataAccessProviderFactory;
 

--- a/src/System.Data.Jet/JetStoreSchemaDefinition/JetRenameHandling.cs
+++ b/src/System.Data.Jet/JetStoreSchemaDefinition/JetRenameHandling.cs
@@ -2,29 +2,26 @@
 
 namespace System.Data.Jet.JetStoreSchemaDefinition
 {
-    class JetRenameHandling
+    internal class JetRenameHandling
     {
-        private static Regex _renameTableRegex = new Regex(
-            $@"^\s*rename\s+table\s+{GetQuotedOrUnquotedNamePattern("tableName")}\s+to\s+{GetQuotedOrUnquotedNamePattern("newTableName")}\s*$",
+        private static readonly Regex _renameTableRegex = new Regex(
+            $@"^\s*rename\s+table\s+{GetIdentifierPattern("OldTableName")}\s+to\s+{GetIdentifierPattern("NewTableName")}\s*$",
             RegexOptions.IgnoreCase);
 
-        private static Regex _renameTableColumnRegex = new Regex(
-            $@"^\s*rename\s+column\s+{GetQuotedOrUnquotedNamePattern("tableName")}\.{GetQuotedOrUnquotedNamePattern("columnName")}\s+to\s+{GetQuotedOrUnquotedNamePattern("newColumnName")}\s*$",
+        private static readonly Regex _renameTableColumnRegex = new Regex(
+            $@"^\s*rename\s+column\s+{GetIdentifierPattern("TableName")}\s*\.\s*{GetIdentifierPattern("OldColumnName")}\s+to\s+{GetIdentifierPattern("NewColumnName")}\s*$",
             RegexOptions.IgnoreCase);
 
         public static bool TryDatabaseOperation(string connectionString, string commandText)
         {
-            Match match;
-
-
-            match = _renameTableRegex.Match(commandText);
+            var match = _renameTableRegex.Match(commandText);
             if (match.Success)
             {
-                string tableName = match.Groups["tableName"].Value;
-                string newTableName = match.Groups["newTableName"].Value;
+                var oldTableName = match.Groups["OldTableName"].Value;
+                var newTableName = match.Groups["NewTableName"].Value;
                 
                 // TODO: Only use ADOX in an OLE DB context. Use DAO in an ODBC context.
-                AdoxWrapper.RenameTable(connectionString, RemoveBrackets(tableName), RemoveBrackets(newTableName));
+                AdoxWrapper.RenameTable(connectionString, oldTableName, newTableName);
                 
                 return true;
             }
@@ -32,28 +29,20 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
             match = _renameTableColumnRegex.Match(commandText);
             if (match.Success)
             {
-                string tableName = match.Groups["tableName"].Value;
-                string columnName = match.Groups["columnName"].Value;
-                string newColumnName = match.Groups["newColumnName"].Value;
-                AdoxWrapper.RenameColumn(connectionString, RemoveBrackets(tableName), RemoveBrackets(columnName), RemoveBrackets(newColumnName));
+                var tableName = match.Groups["TableName"].Value;
+                var oldColumnName = match.Groups["OldColumnName"].Value;
+                var newColumnName = match.Groups["NewColumnName"].Value;
+                
+                // TODO: Only use ADOX in an OLE DB context. Use DAO in an ODBC context.
+                AdoxWrapper.RenameColumn(connectionString, tableName, oldColumnName, newColumnName);
+                
                 return true;
             }
 
             return false;
         }
 
-        private static string RemoveBrackets(string name)
-        {
-            if (name.StartsWith("[") && name.EndsWith("]"))
-                return name.Substring(1, name.Length - 2);
-            else
-                return name;
-        }
-
-
-        static string GetQuotedOrUnquotedNamePattern(string key)
-        {
-            return $@"((?<{key}>\S*)|\[(?<{key}>.*)\])";
-        }
+        private static string GetIdentifierPattern(string key)
+            => $@"(?:`(?<{key}>.*?)`|\[(?<{key}>.*?)\]|(?<{key}>\S*))";
     }
 }

--- a/src/System.Data.Jet/JetStoreSchemaDefinition/JetRenameHandling.cs
+++ b/src/System.Data.Jet/JetStoreSchemaDefinition/JetRenameHandling.cs
@@ -22,7 +22,10 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
             {
                 string tableName = match.Groups["tableName"].Value;
                 string newTableName = match.Groups["newTableName"].Value;
+                
+                // TODO: Only use ADOX in an OLE DB context. Use DAO in an ODBC context.
                 AdoxWrapper.RenameTable(connectionString, RemoveBrackets(tableName), RemoveBrackets(newTableName));
+                
                 return true;
             }
 

--- a/src/System.Data.Jet/JetStoreSchemaDefinition/JetStoreDatabaseHandling.cs
+++ b/src/System.Data.Jet/JetStoreSchemaDefinition/JetStoreDatabaseHandling.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
@@ -9,13 +11,15 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
         private static readonly Regex _regExIsCreateOrDropDatabaseCommand;
         private static readonly Regex _regExParseCreateDatabaseCommand;
         private static readonly Regex _regExParseDropDatabaseCommand;
+        private static readonly Regex _regExIsConnectionString;
+        private static readonly Regex _regExHasProvider;
+        private static readonly Regex _regExExtractFilenameFromConnectionString;
 
         // TODO: Remove this obsolete block for .NET 5.
         private static readonly Regex _regExParseObsoleteCreateDatabaseCommand;
         private static readonly Regex _regExParseObsoleteDropDatabaseCommand;
         private static readonly Regex _regExParseObsoleteCreateDatabaseCommandFromConnection;
         private static readonly Regex _regExParseObsoleteDropDatabaseCommandFromConnection;
-        private static readonly Regex _regExExtractFilenameFromConnectionString;
 
         static JetStoreDatabaseHandling()
         {
@@ -33,29 +37,43 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
                 @"^\s*drop\s+database\s+'\s*(?<filename>(?:''|[^'])*)\s*'\s*(?:;|$)",
                 RegexOptions.IgnoreCase);
 
+            // Provider=Microsoft.ACE.OLEDB.12.0
+            // Driver=Microsoft.ACE.OLEDB.12.0
+            // Data Source=Joe's Database.accdb
+            // DBQ=Joe's Database.accdb
+            _regExIsConnectionString = new Regex(
+                @"^(?:.*;)?\s*(?:provider|driver|data source|dbq)\s*=",
+                RegexOptions.IgnoreCase);
+
+            // Provider=Microsoft.ACE.OLEDB.12.0
+            // Driver=Microsoft.ACE.OLEDB.12.0
+            _regExHasProvider = new Regex(
+                @"^(?:.*;)?\s*(?:provider|driver)\s*=",
+                RegexOptions.IgnoreCase);
+
+            // Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Joe's Database.accdb;
+            _regExExtractFilenameFromConnectionString = new Regex(
+                @"^(?:.*;)?\s*(?:data source|dbq)\s*=\s*(?<filename>.*?)\s*(?:;|$)",
+                RegexOptions.IgnoreCase);
+
             // CREATE DATABASE Joe's Database.accdb;
             _regExParseObsoleteCreateDatabaseCommand = new Regex(
                 @"^\s*create\s+database\s+(?<filename>.*?)\s*(?:;|$)",
                 RegexOptions.IgnoreCase);
 
-            // DROP DATABASE 'Joe's Database.accdb';
+            // DROP DATABASE Joe's Database.accdb;
             _regExParseObsoleteDropDatabaseCommand = new Regex(
                 @"^\s*drop\s+database\s+(?<filename>.*?)\s*(?:;|$)",
                 RegexOptions.IgnoreCase);
 
-            // CREATE DATABASE Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Joe's Database.accdb';
+            // CREATE DATABASE Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Joe's Database.accdb;
             _regExParseObsoleteCreateDatabaseCommandFromConnection = new Regex(
                 @"^\s*create\s+database\s+(?<connectionString>(provider)\s*=\s*.*?)\s*$",
                 RegexOptions.IgnoreCase);
 
-            // DROP DATABASE Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Joe's Database.accdb';
+            // DROP DATABASE Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Joe's Database.accdb;
             _regExParseObsoleteDropDatabaseCommandFromConnection = new Regex(
                 @"^\s*drop\s+database\s+(?<connectionString>provider\s*=\s*.*?)\s*$",
-                RegexOptions.IgnoreCase);
-
-            // Provider=Microsoft.ACE.OLEDB.12.0;Data Source=Joe's Database.accdb';
-            _regExExtractFilenameFromConnectionString = new Regex(
-                @"(?:.*;)?\s*(?:data source|dbq)\s*=\s*(?<filename>.*?)\s*(?:;|$)",
                 RegexOptions.IgnoreCase);
         }
 
@@ -161,6 +179,19 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
             return fileName;
         }
 
+        public static bool IsConnectionString(string connectionString)
+            => _regExIsConnectionString.IsMatch(connectionString);
+
+        public static bool IsFileName(string fileName)
+            => !string.IsNullOrWhiteSpace(fileName) &&
+               !IsConnectionString(fileName) &&
+               !fileName.ToCharArray()
+                   .Intersect(Path.GetInvalidPathChars())
+                   .Any();
+        
+        public static bool HasProvider(string connectionString)
+            => _regExHasProvider.IsMatch(connectionString);
+        
         public static void DeleteFile(string fileName)
         {
             if (!File.Exists(fileName))

--- a/src/System.Data.Jet/JetStoreSchemaDefinition/JetStoreSchemaDefinitionRetrieve.cs
+++ b/src/System.Data.Jet/JetStoreSchemaDefinition/JetStoreSchemaDefinitionRetrieve.cs
@@ -85,8 +85,8 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
                 if (showStatementPosition == -1)
                     continue;
 
-                commandText = commandText.ReplaceCaseInsensitive("\\(\\s*show " + table.Name + "\\s*\\)", "[" + table.TableName + "]");
-                commandText = commandText.ReplaceCaseInsensitive("show " + table.Name, "[" + table.TableName + "]");
+                commandText = commandText.ReplaceCaseInsensitive("\\(\\s*show " + table.Name + "\\s*\\)", "`" + table.TableName + "`");
+                commandText = commandText.ReplaceCaseInsensitive("show " + table.Name, "`" + table.TableName + "`");
                 tablesToCreate.Add(table);
             }
 
@@ -174,13 +174,13 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
                         values += ", ";
                     }
 
-                    columns += string.Format("[{0}]", column.ColumnName);
+                    columns += string.Format("`{0}`", column.ColumnName);
                     object value = row[column];
                     values += JetSyntaxHelper.ToSqlStringSwitch(value);
                 }
             }
 
-            return string.Format("INSERT INTO [{0}] ({1}) VALUES ({2})", tableName, columns, values);
+            return string.Format("INSERT INTO `{0}` ({1}) VALUES ({2})", tableName, columns, values);
         }
 
         [DebuggerStepThrough]

--- a/src/System.Data.Jet/JetStoreSchemaDefinition/SystemTableCollection.cs
+++ b/src/System.Data.Jet/JetStoreSchemaDefinition/SystemTableCollection.cs
@@ -71,11 +71,11 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
 
             foreach (SystemTable table in this)
             {
-                table.DropStatement = string.Format("DROP TABLE [{0}]", table.TableName);
-                table.ClearStatement = string.Format("DELETE FROM [{0}]", table.TableName);
+                table.DropStatement = string.Format("DROP TABLE `{0}`", table.TableName);
+                table.ClearStatement = string.Format("DELETE FROM `{0}`", table.TableName);
                 
                 StringBuilder createStatementStringBuilder = new StringBuilder();
-                createStatementStringBuilder.AppendFormat("CREATE TABLE [{0}]\r\n", table.TableName);
+                createStatementStringBuilder.AppendFormat("CREATE TABLE `{0}`\r\n", table.TableName);
                 createStatementStringBuilder.Append("(");
                 bool first = true;
                 foreach (Column column in table.Columns)
@@ -85,7 +85,7 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
                     else
                         createStatementStringBuilder.Append(",");
                     createStatementStringBuilder.AppendLine();
-                    createStatementStringBuilder.AppendFormat("    [{0}] {1}{2} {3}", 
+                    createStatementStringBuilder.AppendFormat("    `{0}` {1}{2} {3}", 
                         column.Name, 
                         column.Type, 
                         column.MaxLength == null ? "" : string.Format("({0})", column.MaxLength), 

--- a/src/System.Data.Jet/JetSyntaxHelper.cs
+++ b/src/System.Data.Jet/JetSyntaxHelper.cs
@@ -15,7 +15,7 @@ namespace System.Data.Jet
         public static string ToSqlString(string value)
         {
             // In Jet everything's unicode
-            return "'" + value.Replace("'", "''") + "'";
+            return $"'{value.Replace("'", "''")}'";
         }
 
         public static string ToSqlString(int value)
@@ -84,9 +84,9 @@ namespace System.Data.Jet
         internal static string QuoteIdentifier(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
 
-            return "[" + name.Replace("]", "]]") + "]";
+            return $"`{name}`";
         }
 
         /// <summary>

--- a/src/System.Data.Jet/System.Data.Jet.csproj
+++ b/src/System.Data.Jet/System.Data.Jet.csproj
@@ -39,6 +39,7 @@
     
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharp)" />
+        <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32Registry)" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/test/EFCore.Jet.FunctionalTests/config.json
+++ b/test/EFCore.Jet.FunctionalTests/config.json
@@ -1,7 +1,7 @@
 {
     "Test": {
       "Jet": {
-        "DefaultConnection": "Driver={Microsoft Access Driver (*.mdb, *.accdb)};DBQ=Jet.accdb;ExtendedAnsiSQL=1"
+        "DefaultConnection": "DBQ=Jet.accdb"
       }
     }
 }


### PR DESCRIPTION
This PR allows to specify just a file name or path as the connection string or omit the driver (ODBC) or provider (OLE DB) part of the connection string.
In those cases, the driver/provider with the most recent version of all installed compatible drivers/providers will be used.
If just a file name is used, `JetConfiguration.DefaultDataAccessProviderType` will be used as the provider type.

Addresses https://github.com/bubibubi/EntityFrameworkCore.Jet/issues/45#issuecomment-605414758

---

This PR also uses a nightly-build of `System.Data.OleDb`, that works inside of x86 processes. See https://github.com/dotnet/runtime/pull/33899 for further details.