### PR TITLE
Fix test related issues

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,14 +1,14 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MicrosoftEntityFrameworkCoreVersion>3.1.2</MicrosoftEntityFrameworkCoreVersion>
-    <MicrosoftEntityFrameworkCoreRelationalVersion>3.1.2</MicrosoftEntityFrameworkCoreRelationalVersion>
-    <MicrosoftExtensionsConfigurationJsonVersion>3.1.2</MicrosoftExtensionsConfigurationJsonVersion>
-    <MicrosoftExtensionsDependencyInjection>3.1.2</MicrosoftExtensionsDependencyInjection>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>3.1.2</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
-    <MicrosoftExtensionsConfigurationVersion>3.1.2</MicrosoftExtensionsConfigurationVersion>
-    <MicrosoftExtensionsCachingMemoryVersion>3.1.2</MicrosoftExtensionsCachingMemoryVersion>
+    <MicrosoftEntityFrameworkCoreVersion>3.1.3</MicrosoftEntityFrameworkCoreVersion>
+    <MicrosoftEntityFrameworkCoreRelationalVersion>3.1.3</MicrosoftEntityFrameworkCoreRelationalVersion>
+    <MicrosoftExtensionsConfigurationJsonVersion>3.1.3</MicrosoftExtensionsConfigurationJsonVersion>
+    <MicrosoftExtensionsDependencyInjection>3.1.3</MicrosoftExtensionsDependencyInjection>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>3.1.3</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
+    <MicrosoftExtensionsConfigurationVersion>3.1.3</MicrosoftExtensionsConfigurationVersion>
+    <MicrosoftExtensionsCachingMemoryVersion>3.1.3</MicrosoftExtensionsCachingMemoryVersion>
     <MicrosoftExtensionsHostFactoryResolverSourcesVersion>3.1.0-rtm.19565.4</MicrosoftExtensionsHostFactoryResolverSourcesVersion>
-    <MicrosoftExtensionsLoggingVersion>3.1.2</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingVersion>3.1.3</MicrosoftExtensionsLoggingVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>4.7.0</SystemDiagnosticsDiagnosticSourceVersion>
     <MicrosoftBclAsyncInterfacesVersion>1.1.0</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftBclHashCodeVersion>1.1.0</MicrosoftBclHashCodeVersion>
@@ -40,7 +40,7 @@
     <SystemComponentModelTypeConverterVersion>4.3.0</SystemComponentModelTypeConverterVersion>
     <CastleCoreVersion>4.4.0</CastleCoreVersion>
     <MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>3.1.0</MicrosoftExtensionsConfigurationEnvironmentVariablesVersion>
-    <MicrosoftExtensionsConfigurationFileExtensionsVersion>3.1.2</MicrosoftExtensionsConfigurationFileExtensionsVersion>
+    <MicrosoftExtensionsConfigurationFileExtensionsVersion>3.1.3</MicrosoftExtensionsConfigurationFileExtensionsVersion>
   </PropertyGroup>
   <!-- EFCore.Jet.Tests -->
   <PropertyGroup>

--- a/src/EFCore.Jet/Infrastructure/Internal/IJetOptions.cs
+++ b/src/EFCore.Jet/Infrastructure/Internal/IJetOptions.cs
@@ -13,5 +13,6 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
     {
         string ConnectionString { get; }
         DataAccessProviderType DataAccessProviderType { get; }
+        bool UseOuterSelectSkipEmulationViaDataReader { get; }
     }
 }

--- a/src/EFCore.Jet/Infrastructure/Internal/JetOptionsExtension.cs
+++ b/src/EFCore.Jet/Infrastructure/Internal/JetOptionsExtension.cs
@@ -22,6 +22,7 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
 
         // private bool? _rowNumberPaging;
         private DbProviderFactory _dataAccessProviderFactory;
+        private bool _useOuterSelectSkipEmulationViaDataReader;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -46,6 +47,7 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
         {
             // _rowNumberPaging = copyFrom._rowNumberPaging;
             _dataAccessProviderFactory = copyFrom._dataAccessProviderFactory;
+            _useOuterSelectSkipEmulationViaDataReader = copyFrom._useOuterSelectSkipEmulationViaDataReader;
         }
 
         /// <summary>
@@ -120,6 +122,29 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual bool UseOuterSelectSkipEmulationViaDataReader => _useOuterSelectSkipEmulationViaDataReader;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual JetOptionsExtension WithUseOuterSelectSkipEmulationViaDataReader(bool enabled)
+        {
+            var clone = (JetOptionsExtension) Clone();
+
+            clone._useOuterSelectSkipEmulationViaDataReader = enabled;
+
+            return clone;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public override void ApplyServices(IServiceCollection services)
             => services.AddEntityFrameworkJet();
 
@@ -160,6 +185,11 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
                             builder.Append("DataAccessProviderFactory ");
                         }
 
+                        if (Extension._useOuterSelectSkipEmulationViaDataReader)
+                        {
+                            builder.Append("UseOuterSelectSkipEmulationViaDataReader ");
+                        }
+
                         _logFragment = builder.ToString();
                     }
 
@@ -172,7 +202,8 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
                 if (_serviceProviderHash == null)
                 {
                     _serviceProviderHash = (base.GetServiceProviderHashCode() * 397) ^
-                                           (Extension._dataAccessProviderFactory?.GetHashCode() ?? 0L) /* ^
+                                           (Extension._dataAccessProviderFactory?.GetHashCode() ?? 0L) ^
+                                           (Extension._useOuterSelectSkipEmulationViaDataReader.GetHashCode() * 397) /* ^
                                            (Extension._rowNumberPaging?.GetHashCode() ?? 0L)*/;
                 }
 
@@ -185,8 +216,12 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
                 debugInfo["Jet:" + nameof(JetDbContextOptionsBuilder.UseRowNumberForPaging)]
                     = (Extension._rowNumberPaging?.GetHashCode() ?? 0L).ToString(CultureInfo.InvariantCulture);
                 */
-                debugInfo["Jet:" + nameof(JetOptionsExtension.DataAccessProviderFactory)]
+                debugInfo["Jet:" + nameof(DataAccessProviderFactory)]
                     = (Extension._dataAccessProviderFactory?.GetHashCode() ?? 0L).ToString(CultureInfo.InvariantCulture);
+#pragma warning disable 618
+                debugInfo["Jet:" + nameof(JetDbContextOptionsBuilder.UseOuterSelectSkipEmulationViaDataReader)]
+#pragma warning restore 618
+                    = Extension._useOuterSelectSkipEmulationViaDataReader.GetHashCode().ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/EFCore.Jet/Infrastructure/JetDbContextOptionsBuilder.cs
+++ b/src/EFCore.Jet/Infrastructure/JetDbContextOptionsBuilder.cs
@@ -41,6 +41,20 @@ namespace EntityFrameworkCore.Jet.Infrastructure
         //    => WithOption(e => e.WithRowNumberPaging(useRowNumberForPaging));
 
         /// <summary>
+        ///     Jet/ACE doesn't natively support row skipping. When this option is enabled, row skipping will be
+        ///     emulated in the most outer SELECT statement, by letting the JetDataReader ignore as many returned rows
+        ///     as should have been skipped by the database.
+        ///     This will only work when `JetCommand.ExecuteDataReader()` is beeing used to execute the `JetCommand`.
+        ///     It is recommanded to not use this option, but to switch to client evaluation instead, by inserting a
+        ///     call to either `AsEnumerable()`, `AsAsyncEnumerable()`, `ToList()`, or `ToListAsync()` and only then
+        ///     to use `Skip()`. This will work in all cases and independent of the specific `JetCommand.Execute()`
+        ///     method called. 
+        /// </summary>
+        [Obsolete("This method exists for backward compatibility reasons only. Switch to client evaluation instead.")]
+        public virtual JetDbContextOptionsBuilder UseOuterSelectSkipEmulationViaDataReader(bool enabled = true)
+            => WithOption(e => e.WithUseOuterSelectSkipEmulationViaDataReader(enabled));
+
+        /// <summary>
         ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
         /// </summary>
         public virtual JetDbContextOptionsBuilder EnableRetryOnFailure()

--- a/src/EFCore.Jet/Internal/JetOptions.cs
+++ b/src/EFCore.Jet/Internal/JetOptions.cs
@@ -27,6 +27,7 @@ namespace EntityFrameworkCore.Jet.Internal
             // RowNumberPagingEnabled = jetOptions.RowNumberPaging ?? false;
             
             DataAccessProviderType = GetDataAccessProviderTypeFromOptions(jetOptions);
+            UseOuterSelectSkipEmulationViaDataReader = jetOptions.UseOuterSelectSkipEmulationViaDataReader;
             ConnectionString = jetOptions.Connection?.ConnectionString ?? jetOptions.ConnectionString;
         }
 
@@ -53,6 +54,14 @@ namespace EntityFrameworkCore.Jet.Internal
                 throw new InvalidOperationException(
                     CoreStrings.SingletonOptionChanged(
                         nameof(JetOptionsExtension.DataAccessProviderFactory),
+                        nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
+            }
+
+            if (UseOuterSelectSkipEmulationViaDataReader != jetOptions.UseOuterSelectSkipEmulationViaDataReader)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.SingletonOptionChanged(
+                        nameof(JetOptionsExtension.UseOuterSelectSkipEmulationViaDataReader),
                         nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
             }
         }
@@ -107,6 +116,14 @@ namespace EntityFrameworkCore.Jet.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual DataAccessProviderType DataAccessProviderType { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool UseOuterSelectSkipEmulationViaDataReader { get; private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Jet/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.Jet/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -37,9 +37,9 @@ namespace EntityFrameworkCore.Jet.Query.Internal
                     {
                         new CaseWhenClause(
                             sqlExpression,
-                            _sqlExpressionFactory.ApplyDefaultTypeMapping(_sqlExpressionFactory.Constant(/*true*/ 1)))
+                            _sqlExpressionFactory.ApplyDefaultTypeMapping(_sqlExpressionFactory.Constant(true)))
                     },
-                    _sqlExpressionFactory.Constant(/*false*/ 0))
+                    _sqlExpressionFactory.Constant(false))
                 : sqlExpression;
         }
 
@@ -268,10 +268,10 @@ namespace EntityFrameworkCore.Jet.Query.Internal
             _isSearchCondition = parentSearchCondition;
             var newFunction = sqlFunctionExpression.Update(instance, arguments);
 
-            var condition = string.Equals(sqlFunctionExpression.Name, "FREETEXT")
-                || string.Equals(sqlFunctionExpression.Name, "CONTAINS");
+            // var condition = string.Equals(sqlFunctionExpression.Name, "FREETEXT")
+            //    || string.Equals(sqlFunctionExpression.Name, "CONTAINS");
 
-            return ApplyConversion(newFunction, condition);
+            return ApplyConversion(newFunction, /* condition */ false);
         }
 
         protected override Expression VisitSqlParameter(SqlParameterExpression sqlParameterExpression)

--- a/src/EFCore.Jet/Query/Sql/Internal/JetQuerySqlGenerator.cs
+++ b/src/EFCore.Jet/Query/Sql/Internal/JetQuerySqlGenerator.cs
@@ -5,11 +5,13 @@ using System.Collections.Generic;
 using System.Data.Jet;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 using EntityFrameworkCore.Jet.Utilities;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
@@ -349,8 +351,7 @@ namespace EntityFrameworkCore.Jet.Query.Sql.Internal
 
             if (selectExpression.Offset != null)
             {
-                // Jet does not support skipping rows. Use client evaluation instead.
-                throw new InvalidOperationException(CoreStrings.TranslationFailed(selectExpression.Offset));
+                throw new InvalidOperationException("Jet does not support skipping rows. Switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync() if needed.");
             }
 
             if (selectExpression.Limit != null)
@@ -430,5 +431,8 @@ namespace EntityFrameworkCore.Jet.Query.Sql.Internal
 
             return caseExpression;
         }
+
+        protected override Expression VisitRowNumber(RowNumberExpression rowNumberExpression)
+            => throw new InvalidOperationException(CoreStrings.TranslationFailed(rowNumberExpression));
     }
 }

--- a/src/EFCore.Jet/Query/Sql/Internal/JetQuerySqlGenerator.cs
+++ b/src/EFCore.Jet/Query/Sql/Internal/JetQuerySqlGenerator.cs
@@ -224,18 +224,16 @@ namespace EntityFrameworkCore.Jet.Query.Sql.Internal
 
         protected override Expression VisitOrdering(OrderingExpression orderingExpression)
         {
-            // Instead of the following, we are using SearchConditionConvertingExpressionVisitor.
-            
             // Jet uses the value -1 as True, so ordering by a boolean expression will first list the True values
             // before the False values, which is the opposite of what .NET and other DBMS do, which are using 1 as True.
-            /*
+            
             if (orderingExpression.Expression.TypeMapping == _boolTypeMapping)
             {
                 orderingExpression = new OrderingExpression(
                     orderingExpression.Expression,
                     !orderingExpression.IsAscending);
             }
-            */
+            
             return base.VisitOrdering(orderingExpression);
         }
 

--- a/src/EFCore.Jet/Query/Sql/Internal/JetQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Jet/Query/Sql/Internal/JetQuerySqlGeneratorFactory.cs
@@ -1,5 +1,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using EntityFrameworkCore.Jet.Infrastructure.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -15,6 +16,7 @@ namespace EntityFrameworkCore.Jet.Query.Sql.Internal
         [NotNull] private readonly QuerySqlGeneratorDependencies _dependencies;
         [NotNull] private readonly JetSqlExpressionFactory _sqlExpressionFactory;
         [NotNull] private readonly ITypeMappingSource _typeMappingSource;
+        [NotNull] private readonly IJetOptions _options;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -23,14 +25,16 @@ namespace EntityFrameworkCore.Jet.Query.Sql.Internal
         public JetQuerySqlGeneratorFactory(
             [NotNull] QuerySqlGeneratorDependencies dependencies,
             [NotNull] ISqlExpressionFactory sqlExpressionFactory,
-            [NotNull] ITypeMappingSource typeMappingSource)
+            [NotNull] ITypeMappingSource typeMappingSource,
+            [NotNull] IJetOptions options)
         {
             _dependencies = dependencies;
             _sqlExpressionFactory = (JetSqlExpressionFactory)sqlExpressionFactory;
             _typeMappingSource = typeMappingSource;
+            _options = options;
         }
 
         public virtual QuerySqlGenerator Create()
-            => new JetQuerySqlGenerator(_dependencies, _sqlExpressionFactory, _typeMappingSource);
+            => new JetQuerySqlGenerator(_dependencies, _sqlExpressionFactory, _typeMappingSource, _options);
     }
 }

--- a/src/EFCore.Jet/Storage/Internal/JetBoolTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetBoolTypeMapping.cs
@@ -23,7 +23,7 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
 
         protected override string GenerateNonNullSqlLiteral(object value)
             => (bool) value
-                ? "True"
-                : "False";
+                ? "TRUE"
+                : "FALSE";
     }
 }

--- a/src/EFCore.Jet/Storage/Internal/JetSqlGenerationHelper.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetSqlGenerationHelper.cs
@@ -1,8 +1,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Data.Jet;
 using System.Text;
-using EntityFrameworkCore.Jet.Infrastructure.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 using EntityFrameworkCore.Jet.Utilities;
@@ -15,18 +13,14 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
     /// </summary>
     public class JetSqlGenerationHelper : RelationalSqlGenerationHelper
     {
-        private readonly IJetOptions _jetOptions;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public JetSqlGenerationHelper(
-            [NotNull] RelationalSqlGenerationHelperDependencies dependencies,
-            [NotNull] IJetOptions jetOptions)
+            [NotNull] RelationalSqlGenerationHelperDependencies dependencies)
             : base(dependencies)
         {
-            _jetOptions = jetOptions;
         }
 
         /// <summary>
@@ -91,23 +85,6 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
             return DelimitIdentifier(Check.NotEmpty(name, nameof(name)));
         }
 
-        public override string GenerateParameterNamePlaceholder(string name)
-            => _jetOptions.DataAccessProviderType == DataAccessProviderType.OleDb
-                ? base.GenerateParameterNamePlaceholder(name)
-                : "?";
-
-        public override void GenerateParameterNamePlaceholder(StringBuilder builder, string name)
-        {
-            if (_jetOptions.DataAccessProviderType == DataAccessProviderType.OleDb)
-            {
-                base.GenerateParameterNamePlaceholder(builder, name);
-            }
-            else
-            {
-                builder.Append("?");
-            }
-        }
-        
         public static string TruncateIdentifier(string identifier)
         {
             if (identifier.Length <= 64)

--- a/src/EFCore.Jet/Update/Internal/JetUpdateSqlGenerator.cs
+++ b/src/EFCore.Jet/Update/Internal/JetUpdateSqlGenerator.cs
@@ -1,8 +1,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Globalization;
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Update;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EntityFrameworkCore.Jet.Update.Internal
 {
@@ -49,23 +52,9 @@ namespace EntityFrameworkCore.Jet.Update.Internal
         /// </summary>
         protected override void AppendRowsAffectedWhereCondition(StringBuilder commandStringBuilder, int expectedRowsAffected)
         {
-            // TODO: Implement translation of @@ROWCOUNT related queries into System.Data.Jet.
-            //       Every the AffectedRecords of every NonQueryExecution needs to be saved per connection,
-            //       so it can be replaced in later queries if needed.
-            //       Other executions should set this saved value just to 0.
-            
-            // Jet does not support ROWCOUNT
-            // Here we really hope that ROWCOUNT is not required
-            // Actually, RecordsAffected is handled by JetModificationCommandBatch
-            commandStringBuilder
-                .Append("1 = 1");
-
-            /*
-
             commandStringBuilder
                 .Append("@@ROWCOUNT = ")
                 .Append(expectedRowsAffected.ToString(CultureInfo.InvariantCulture));
-            */
         }
 
         /// <summary>

--- a/src/System.Data.Jet/AdoxWrapper.cs
+++ b/src/System.Data.Jet/AdoxWrapper.cs
@@ -95,7 +95,7 @@ namespace System.Data.Jet
                 connection.DataAccessProviderFactory = dataAccessProviderFactory;
                 connection.Open();
                 
-                var sql = @"CREATE TABLE `MSysAccessStorage` (
+                var script = @"CREATE TABLE `MSysAccessStorage` (
     `DateCreate` DATETIME NULL,
     `DateUpdate` DATETIME NULL,
     `Id` COUNTER NOT NULL,
@@ -108,8 +108,11 @@ namespace System.Data.Jet
 CREATE UNIQUE INDEX `ParentIdId` ON `MSysAccessStorage` (`ParentId`, `Id`);
 CREATE UNIQUE INDEX `ParentIdName` ON `MSysAccessStorage` (`ParentId`, `Name`);";
 
-                using var command = connection.CreateCommand(sql);
-                command.ExecuteNonQuery();
+                foreach (var commandText in script.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    using var command = connection.CreateCommand(commandText);
+                    command.ExecuteNonQuery();
+                }
             }
             catch (Exception e)
             {

--- a/src/System.Data.Jet/JetCommand.cs
+++ b/src/System.Data.Jet/JetCommand.cs
@@ -326,6 +326,7 @@ namespace System.Data.Jet
                 return DBNull.Value;
             }
 
+            FixupGlobalVariables();
             InlineTopParameters();
             FixParameters();
 

--- a/src/System.Data.Jet/JetCommandParser.cs
+++ b/src/System.Data.Jet/JetCommandParser.cs
@@ -1,0 +1,233 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace System.Data.Jet
+{
+    public class JetCommandParser
+    {
+        public string SqlFragment { get; }
+        public char[] States { get; }
+
+        public JetCommandParser(string sqlFragment)
+        {
+            SqlFragment = sqlFragment ?? throw new ArgumentNullException(nameof(sqlFragment));
+            States = new char[sqlFragment.Length];
+
+            Parse();
+        }
+
+        public IReadOnlyList<int> GetStateIndices(char state, int start = 0, int length = -1)
+        {
+            if (start < 0 ||
+                start >= States.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(start));
+            }
+
+            if (length < 0 ||
+                length > 0 && start + length > States.Length)
+            {
+                length = States.Length - start;
+            }
+
+            var stateIndices = new List<int>();
+            char? lastState = null;
+
+            for (var i = start; i < length; i++)
+            {
+                var currentState = States[i];
+
+                if (currentState == state &&
+                    currentState != lastState)
+                {
+                    stateIndices.Add(i);
+                }
+
+                lastState = currentState;
+            }
+
+            return stateIndices.AsReadOnly();
+        }
+
+        public IReadOnlyList<int> GetStateIndices(char[] states, int start = 0, int length = -1)
+        {
+            if (states == null)
+            {
+                throw new ArgumentNullException(nameof(states));
+            }
+
+            if (states.Length <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(states));
+            }
+
+            if (start < 0 ||
+                start >= States.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(start));
+            }
+
+            if (length < 0 ||
+                length > 0 && start + length > States.Length)
+            {
+                length = States.Length - start;
+            }
+
+            var stateIndices = new List<int>();
+            char? lastState = null;
+
+            for (var i = start; i < length; i++)
+            {
+                var currentState = States[i];
+
+                if (currentState != lastState &&
+                    states.Contains(currentState))
+                {
+                    stateIndices.Add(i);
+                }
+
+                lastState = currentState;
+            }
+
+            return stateIndices.AsReadOnly();
+        }
+
+        protected virtual void Parse()
+        {
+            // We use '\0' as the default state and char.
+            var state = '\0';
+            var lastChar = '\0';
+
+            // State machine to parse ODBC and OleDB SQL.
+            for (var i = 0; i < SqlFragment.Length; i++)
+            {
+                var c = SqlFragment[i];
+
+                if (state == '\'')
+                {
+                    // We are currently inside a string, or closed the string in the last iteration but didn't
+                    // know that at the time, because it still could have been the beginning of an escape sequence.
+
+                    if (c == '\'')
+                    {
+                        // We either end the string, begin an escape sequence or end an escape sequence.
+                        if (lastChar == '\'')
+                        {
+                            // This is the end of an escape sequence.
+                            // We continue being in a string.
+                            lastChar = '\0';
+                        }
+                        else
+                        {
+                            // This is either the beginning of an escape sequence, or the end of the string.
+                            // We will know the in the next iteration.
+                            lastChar = '\'';
+                        }
+                    }
+                    else if (lastChar == '\'')
+                    {
+                        // The last iteration was the end of a string.
+                        // Reset the current state and continue processing the current char.
+                        state = '\0';
+                        lastChar = '\0';
+                        States[i - 1] = state;
+                    }
+                }
+
+                if (state == '"')
+                {
+                    // We are currently inside a string, or closed the string in the last iteration but didn't
+                    // know that at the time, because it still could have been the beginning of an escape sequence.
+
+                    if (c == '"')
+                    {
+                        // We either end the string, begin an escape sequence or end an escape sequence.
+                        if (lastChar == '"')
+                        {
+                            // This is the end of an escape sequence.
+                            // We continue being in a string.
+                            lastChar = '\0';
+                        }
+                        else
+                        {
+                            // This is either the beginning of an escape sequence, or the end of the string.
+                            // We will know the in the next iteration.
+                            lastChar = '"';
+                        }
+                    }
+                    else if (lastChar == '"')
+                    {
+                        // The last iteration was the end of a string.
+                        // Reset the current state and continue processing the current char.
+                        state = '\0';
+                        lastChar = '\0';
+                        States[i - 1] = state;
+                    }
+                }
+
+                if (state == '\0')
+                {
+                    if (c == '"')
+                    {
+                        state = '"';
+                    }
+                    else if (c == '\'')
+                    {
+                        state = '\'';
+                    }
+                    else if (c == '`')
+                    {
+                        state = '`';
+                    }
+                    else if (c == '?')
+                    {
+                        States[i] = '?';
+                    }
+                    else if (c == '@')
+                    {
+                        // This is either the beginning of a named parameter, or a global variable like @@identity.
+                        state = '@';
+                    }
+                    else if (c == ';')
+                    {
+                        States[i] = ';';
+                    }
+                }
+                else if (state == '`' &&
+                         c == '`')
+                {
+                    state = '\0';
+                }
+                else if (state == '@')
+                {
+                    if (c == '@')
+                    {
+                        // This has not been a named parameter, but a global variable.
+                        // We use '$' to signal a global variable like @@identity.
+                        States[i - 1] = '$';
+                    }
+
+                    state = '\0';
+                }
+
+                if (state != '\0')
+                {
+                    States[i] = state;
+                }
+            }
+
+            //
+            // Handle still pending states:
+            //
+
+            if (state == '\'' && lastChar == '\'' ||
+                state == '"' && lastChar == '"')
+            {
+                // The last iteration was the end of a string.
+                state = '\0';
+                lastChar = '\0';
+                States[States.Length - 1] = state;
+            }
+        }
+    }
+}

--- a/src/System.Data.Jet/JetConnection.cs
+++ b/src/System.Data.Jet/JetConnection.cs
@@ -18,6 +18,8 @@ namespace System.Data.Jet
         internal DbConnection InnerConnection { get; private set; }
 
         internal JetTransaction ActiveTransaction { get; set; }
+        
+        internal int RowCount { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JetConnection"/> class.
@@ -371,6 +373,7 @@ namespace System.Data.Jet
                     JetFactory.InnerFactory);
                 InnerConnection.StateChange += WrappedConnection_StateChange;
 
+                RowCount = 0;
                 _state = ConnectionState.Open;
                 OnStateChange(new StateChangeEventArgs(ConnectionState.Closed, ConnectionState.Open));
             }

--- a/src/System.Data.Jet/JetDataReader.cs
+++ b/src/System.Data.Jet/JetDataReader.cs
@@ -18,19 +18,7 @@ namespace System.Data.Jet
             _wrappedDataReader = dataReader;
         }
 
-        public JetDataReader(DbDataReader dataReader, int topCount, int skipCount)
-            : this(dataReader)
-        {
-            _topCount = topCount;
-            for (var i = 0; i < skipCount; i++)
-            {
-                _wrappedDataReader.Read();
-            }
-        }
-
         private readonly DbDataReader _wrappedDataReader;
-        private readonly int _topCount;
-        private int _readCount;
 
         public override void Close()
         {
@@ -118,34 +106,22 @@ namespace System.Data.Jet
             => GetDateTime(ordinal) - JetConfiguration.TimeSpanOffset;
 
         public virtual DateTimeOffset GetDateTimeOffset(int ordinal)
-        {
-            return GetDateTime(ordinal);
-        }
+            => GetDateTime(ordinal);
 
         public override decimal GetDecimal(int ordinal)
-        {
-            return Convert.ToDecimal(_wrappedDataReader.GetValue(ordinal));
-        }
+            => Convert.ToDecimal(_wrappedDataReader.GetValue(ordinal));
 
         public override double GetDouble(int ordinal)
-        {
-            return Convert.ToDouble(_wrappedDataReader.GetValue(ordinal));
-        }
+            => Convert.ToDouble(_wrappedDataReader.GetValue(ordinal));
 
         public override System.Collections.IEnumerator GetEnumerator()
-        {
-            return _wrappedDataReader.GetEnumerator();
-        }
+            => _wrappedDataReader.GetEnumerator();
 
         public override Type GetFieldType(int ordinal)
-        {
-            return _wrappedDataReader.GetFieldType(ordinal);
-        }
+            => _wrappedDataReader.GetFieldType(ordinal);
 
         public override float GetFloat(int ordinal)
-        {
-            return Convert.ToSingle(_wrappedDataReader.GetValue(ordinal));
-        }
+            => Convert.ToSingle(_wrappedDataReader.GetValue(ordinal));
 
         public override Guid GetGuid(int ordinal)
         {
@@ -158,9 +134,7 @@ namespace System.Data.Jet
         }
 
         public override short GetInt16(int ordinal)
-        {
-            return Convert.ToInt16(_wrappedDataReader.GetValue(ordinal));
-        }
+            => Convert.ToInt16(_wrappedDataReader.GetValue(ordinal));
 
         public override int GetInt32(int ordinal)
         {
@@ -177,34 +151,22 @@ namespace System.Data.Jet
         }
 
         public override long GetInt64(int ordinal)
-        {
-            return Convert.ToInt64(_wrappedDataReader.GetValue(ordinal));
-        }
+            => Convert.ToInt64(_wrappedDataReader.GetValue(ordinal));
 
         public override string GetName(int ordinal)
-        {
-            return _wrappedDataReader.GetName(ordinal);
-        }
+            => _wrappedDataReader.GetName(ordinal);
 
         public override int GetOrdinal(string name)
-        {
-            return _wrappedDataReader.GetOrdinal(name);
-        }
+            => _wrappedDataReader.GetOrdinal(name);
 
-        public override System.Data.DataTable GetSchemaTable()
-        {
-            return _wrappedDataReader.GetSchemaTable();
-        }
+        public override DataTable GetSchemaTable()
+            => _wrappedDataReader.GetSchemaTable();
 
         public override string GetString(int ordinal)
-        {
-            return _wrappedDataReader.GetString(ordinal);
-        }
+            => _wrappedDataReader.GetString(ordinal);
 
         public override object GetValue(int ordinal)
-        {
-            return _wrappedDataReader.GetValue(ordinal);
-        }
+            => _wrappedDataReader.GetValue(ordinal);
 
         public override T GetFieldValue<T>(int ordinal)
         {
@@ -217,9 +179,7 @@ namespace System.Data.Jet
         }
 
         public override int GetValues(object[] values)
-        {
-            return _wrappedDataReader.GetValues(values);
-        }
+            => _wrappedDataReader.GetValues(values);
 
         public override bool HasRows
             => _wrappedDataReader.HasRows;
@@ -237,18 +197,10 @@ namespace System.Data.Jet
         }
 
         public override bool NextResult()
-        {
-            return _wrappedDataReader.NextResult();
-        }
+            => _wrappedDataReader.NextResult();
 
         public override bool Read()
-        {
-            _readCount++;
-            if (_topCount != 0 && _readCount > _topCount)
-                return false;
-
-            return _wrappedDataReader.Read();
-        }
+            => _wrappedDataReader.Read();
 
         public override int RecordsAffected
             => _wrappedDataReader.RecordsAffected;

--- a/src/System.Data.Jet/JetDataReader.cs
+++ b/src/System.Data.Jet/JetDataReader.cs
@@ -17,6 +17,16 @@ namespace System.Data.Jet
 #endif
             _wrappedDataReader = dataReader;
         }
+        
+        public JetDataReader(DbDataReader dataReader, int skipCount)
+            : this(dataReader)
+        {
+            var i = 0;
+            while (i < skipCount && _wrappedDataReader.Read())
+            {
+                i++;
+            }
+        }
 
         private readonly DbDataReader _wrappedDataReader;
 

--- a/src/System.Data.Jet/JetStoreSchemaDefinition/JetStoreSchemaDefinitionRetrieve.cs
+++ b/src/System.Data.Jet/JetStoreSchemaDefinition/JetStoreSchemaDefinitionRetrieve.cs
@@ -33,17 +33,17 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
 
         public static bool TryGetDataReaderFromShowCommand(DbCommand command, DbProviderFactory providerFactory, out DbDataReader dataReader)
         {
-            if (command.CommandType == CommandType.Text && command.CommandText.Trim()
-                .StartsWith("show ", StringComparison.InvariantCultureIgnoreCase))
+            if (command.CommandType == CommandType.Text &&
+                command.CommandText.IndexOf("show ", StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                dataReader = GetDbDataReaderFromSimpleStatement(command.Connection, command.CommandText);
-                lock (_lastStructureDataTableLock)
-                    _lastTableName = null;
-                return true;
-            }
+                if (command.CommandText.Trim().StartsWith("show ", StringComparison.OrdinalIgnoreCase))
+                {
+                    dataReader = GetDbDataReaderFromSimpleStatement(command.Connection, command.CommandText);
+                    lock (_lastStructureDataTableLock)
+                        _lastTableName = null;
+                    return true;
+                }
 
-            if (command.CommandType == CommandType.Text && command.CommandText.IndexOf("show ", 0, StringComparison.InvariantCultureIgnoreCase) != 0)
-            {
                 bool isSchemaTable = false;
                 foreach (SystemTable table in _systemTables)
                 {
@@ -63,6 +63,7 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
 
             lock (_lastStructureDataTableLock)
                 _lastTableName = null;
+            
             dataReader = null;
             return false;
         }

--- a/test/EFCore.Jet.FunctionalTests/TestUtilities/AssertSqlHelper.cs
+++ b/test/EFCore.Jet.FunctionalTests/TestUtilities/AssertSqlHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data.Jet;
 
 namespace EntityFrameworkCore.Jet.FunctionalTests.TestUtilities
@@ -18,5 +19,13 @@ namespace EntityFrameworkCore.Jet.FunctionalTests.TestUtilities
             => dataAccessProviderType == DataAccessProviderType.Odbc
                 ? "?"
                 : name;
+
+        public static string Declaration(string fullDeclaration)
+            => Declaration(fullDeclaration, DataAccessProviderType);
+
+        public static string Declaration(string fullDeclaration, DataAccessProviderType dataAccessProviderType)
+            => dataAccessProviderType == DataAccessProviderType.Odbc
+                ? string.Empty
+                : fullDeclaration;
     }
 }

--- a/test/JetProviderExceptionTests/JetProviderExceptionTests.csproj
+++ b/test/JetProviderExceptionTests/JetProviderExceptionTests.csproj
@@ -11,8 +11,8 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(MicrosoftExtensionsConfigurationFileExtensionsVersion)" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonVersion)" />
 
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingVersion)" />
         <PackageReference Include="System.Data.Odbc" Version="5.0.0-preview.3.20171.3" />
         <PackageReference Include="System.Data.OleDb" Version="5.0.0-preview.3.20171.3" />
     </ItemGroup>


### PR DESCRIPTION
Add ODBC named parameters (optional). This allows for reliable parameter substitution with values. To make this work, support for multiple statements in a single `JetCommand` needed to be removed.

Removes the very limited (previously existing) `.Skip()` support. It only worked partially in some simple cases, was unreliable and didn't really skip the records (it needed to retrieve them, but would skip materializing them).
Instead, we throw an exception now. Users that need skip functionality need to be made aware, that this is not natively supported by Jet/ACE and that they need to skip records in client evaluation mode (LINQ to Objects) after the database query has returned.

Use the native `TOP` implementation of Jet/ACE.

Fix bool value mapping and sorting.

Fix join statement generation.