### PR TITLE
Change default data access library to ODBC and improve file extension handling

### DIFF
--- a/src/System.Data.Jet/JetConfiguration.cs
+++ b/src/System.Data.Jet/JetConfiguration.cs
@@ -31,7 +31,7 @@
             }
         }
         
-        public static DataAccessProviderType DefaultDataAccessProviderType { get; set; } = DataAccessProviderType.OleDb; 
+        public static DataAccessProviderType DefaultDataAccessProviderType { get; set; } = DataAccessProviderType.Odbc; 
         
         // The SQL statement
         //

--- a/src/System.Data.Jet/JetConnection.cs
+++ b/src/System.Data.Jet/JetConnection.cs
@@ -572,8 +572,9 @@ namespace System.Data.Jet
 
         public static bool DatabaseExists(string fileNameOrConnectionString)
         {
-            var fileName = JetStoreDatabaseHandling.ExtractFileNameFromConnectionString(fileNameOrConnectionString)
-                .Trim('"');
+            var fileName = JetStoreDatabaseHandling.ExpandFileName(
+                JetStoreDatabaseHandling.ExtractFileNameFromConnectionString(fileNameOrConnectionString)
+                    .Trim('"'));
 
             if (string.IsNullOrWhiteSpace(fileName))
                 throw new InvalidOperationException("The file name or connection string is invalid.");

--- a/src/System.Data.Jet/JetStoreSchemaDefinition/JetStoreDatabaseHandling.cs
+++ b/src/System.Data.Jet/JetStoreSchemaDefinition/JetStoreDatabaseHandling.cs
@@ -195,16 +195,33 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
         
         public static void DeleteFile(string fileName)
         {
-            if (!File.Exists(fileName))
-                return;
-
             JetConnection.ClearAllPools();
+
+            fileName = ExpandFileName(fileName);
+            
+            var directoryPath = Path.GetDirectoryName(fileName) ?? string.Empty;
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+            var extension = Path.GetExtension(fileName);
+
+            if (!File.Exists(fileName))
+            {
+                return;
+            }
 
             File.Delete(fileName);
 
-            if (string.Equals(Path.GetExtension(fileName), "accdb", StringComparison.OrdinalIgnoreCase))
+            if (string.IsNullOrEmpty(extension) ||
+                string.Equals(extension, ".accdb", StringComparison.OrdinalIgnoreCase) ||
+                !string.Equals(extension, ".mdb", StringComparison.OrdinalIgnoreCase))
             {
-                File.Delete(Path.Combine(Path.GetDirectoryName(fileName), Path.GetFileNameWithoutExtension(fileName) + ".laccdb"));
+                File.Delete(Path.Combine(directoryPath, fileNameWithoutExtension + ".laccdb"));
+            }
+            
+            if (string.IsNullOrEmpty(extension) ||
+                string.Equals(extension, ".mdb", StringComparison.OrdinalIgnoreCase) ||
+                !string.Equals(extension, ".accdb", StringComparison.OrdinalIgnoreCase))
+            {
+                File.Delete(Path.Combine(directoryPath, fileNameWithoutExtension + ".ldb"));
             }
         }
 
@@ -227,7 +244,18 @@ namespace System.Data.Jet.JetStoreSchemaDefinition
                 fileName = Path.Combine(dataDirectory, fileName.Substring("|DataDirectory|".Length));
             }
 
-            return Path.GetFullPath(fileName);
+            return EnsureFileExtension(Path.GetFullPath(fileName));
+        }
+
+        public static string EnsureFileExtension(string fileName)
+        {
+            var extension = Path.GetExtension(fileName);
+            if (string.IsNullOrEmpty(extension))
+            {
+                fileName += ".accdb";
+            }
+
+            return fileName;
         }
     }
 }


### PR DESCRIPTION
The improved file extension handling provides a more consistent behavior if no explicit file extension is being used or a database is dropped and a corresponding lock file still exists.