### PR TITLE
Use new information schema syntax for HistoryRepository checks

### DIFF
--- a/src/EFCore.Jet/Migrations/Internal/JetHistoryRepository.cs
+++ b/src/EFCore.Jet/Migrations/Internal/JetHistoryRepository.cs
@@ -51,7 +51,7 @@ namespace EntityFrameworkCore.Jet.Migrations.Internal
 
                 var builder = new StringBuilder();
                 builder
-                    .Append("SHOW TABLES WHERE NAME=")
+                    .Append("SELECT * FROM `INFORMATION_SCHEMA.TABLES` WHERE `TABLE_NAME` = ")
                     .Append(stringTypeMapping.GenerateSqlLiteral(TableName));
 
                 return builder.ToString();
@@ -131,7 +131,7 @@ namespace EntityFrameworkCore.Jet.Migrations.Internal
             var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
 
             builder
-                .Append("IF NOT EXISTS (SELECT * FROM (SHOW TABLES) WHERE Name = ")
+                .Append("IF NOT EXISTS (SELECT * FROM `INFORMATION_SCHEMA.TABLES` WHERE `TABLE_NAME` = ")
                 .Append(stringTypeMapping.GenerateSqlLiteral(TableName))
                 .Append(") THEN ");
             using (builder.Indent())

--- a/src/EFCore.Jet/Migrations/Internal/JetHistoryRepository.cs
+++ b/src/EFCore.Jet/Migrations/Internal/JetHistoryRepository.cs
@@ -2,11 +2,14 @@
 
 using System;
 using System.Text;
+using EntityFrameworkCore.Jet.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using EntityFrameworkCore.Jet.Utilities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EntityFrameworkCore.Jet.Migrations.Internal
 {
@@ -151,20 +154,7 @@ namespace EntityFrameworkCore.Jet.Migrations.Internal
         /// </summary>
         public override string GetBeginIfNotExistsScript(string migrationId)
         {
-            Check.NotEmpty(migrationId, nameof(migrationId));
-
-            var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
-
-            return new StringBuilder()
-                .Append("IF NOT EXISTS(SELECT * FROM ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(TableName))
-                .Append(" WHERE ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(MigrationIdColumnName))
-                .Append(" = ")
-                .Append(stringTypeMapping.GenerateSqlLiteral(migrationId))
-                .AppendLine(")")
-                .Append("THEN")
-                .ToString();
+            throw new NotSupportedException(JetStrings.MigrationScriptGenerationNotSupported);
         }
 
         /// <summary>
@@ -175,20 +165,7 @@ namespace EntityFrameworkCore.Jet.Migrations.Internal
         /// </summary>
         public override string GetBeginIfExistsScript(string migrationId)
         {
-            Check.NotEmpty(migrationId, nameof(migrationId));
-
-            var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
-
-            return new StringBuilder()
-                .Append("IF EXISTS(SELECT * FROM ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(TableName))
-                .Append(" WHERE ")
-                .Append(SqlGenerationHelper.DelimitIdentifier(MigrationIdColumnName))
-                .Append(" = ")
-                .Append(stringTypeMapping.GenerateSqlLiteral(migrationId))
-                .AppendLine(")")
-                .Append("THEN")
-                .ToString();
+            throw new NotSupportedException(JetStrings.MigrationScriptGenerationNotSupported);
         }
 
         /// <summary>
@@ -197,6 +174,9 @@ namespace EntityFrameworkCore.Jet.Migrations.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override string GetEndIfScript() => ";" + Environment.NewLine;
+        public override string GetEndIfScript()
+        {
+            throw new NotSupportedException(JetStrings.MigrationScriptGenerationNotSupported);
+        }
     }
 }

--- a/src/EFCore.Jet/Properties/JetStrings.Designer.cs
+++ b/src/EFCore.Jet/Properties/JetStrings.Designer.cs
@@ -20,6 +20,12 @@ namespace EntityFrameworkCore.Jet.Internal
     {
         private static readonly ResourceManager _resourceManager
             = new ResourceManager("EntityFrameworkCore.Jet.Properties.JetStrings", typeof(JetStrings).GetTypeInfo().Assembly);
+        
+        /// <summary>
+        ///     Generating idempotent scripts for migration is not currently supported by Jet. For more information, see http://go.microsoft.com/fwlink/?LinkId=723262.
+        /// </summary>
+        public static string MigrationScriptGenerationNotSupported
+            => GetString("MigrationScriptGenerationNotSupported");
 
         /// <summary>
         ///     Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.

--- a/src/EFCore.Jet/Properties/JetStrings.resx
+++ b/src/EFCore.Jet/Properties/JetStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="MigrationScriptGenerationNotSupported" xml:space="preserve">
+    <value>Generating idempotent scripts for migration is not currently supported by Jet. For more information, see https://github.com/bubibubi/EntityFrameworkCore.Jet/wiki.</value>
+  </data>
   <data name="IdentityBadType" xml:space="preserve">
     <value>Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.</value>
   </data>


### PR DESCRIPTION
The JetHistoryRepository was still using the old `SHOW TABLES` syntax.

While we are at it, we also now throw if any of the block methods (used for idempotent scripts) is being called, because Jet does not have procedural `IF` statements etc., so the previous code would just fail.

However, since we are already parsing the commands anyway, and also support the simple `IF (NOT) EXISTS (foo) THEN` syntax, we could actually support `IF...BEGIN...END` blocks in the future, if there is need in the community for it.
But since this is all provider customized syntax, a generated idempotent script would need to be executed using `System.Data.Jet` to work, so we should provide a simple script execution class and a wrapper command line tool for that.

Fixes #69 