### PR TITLE
Trim called without arguments throws index out of range

### DIFF
--- a/src/EFCore.Jet/Query/ExpressionTranslators/Internal/JetStringMethodTranslator.cs
+++ b/src/EFCore.Jet/Query/ExpressionTranslators/Internal/JetStringMethodTranslator.cs
@@ -110,8 +110,8 @@ namespace EntityFrameworkCore.Jet.Query.ExpressionTranslators.Internal
             // Jet TRIM does not take arguments.
             // _trimWithNoParam is only available since .NET Core 2.0 (or .NET Standard 2.1).
             if (Equals(method, _trimWithNoParam) ||
-                Equals(method, _trimWithChars) &&
-                (!arguments.Any() || (arguments[0] as SqlConstantExpression)?.Value == null || ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0))
+                Equals(method, _trimWithChars) && ((arguments[0] as SqlConstantExpression)?.Value == null ||
+                 ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0))
             {
                 return _sqlExpressionFactory.Function("TRIM", new[] {instance}, method.ReturnType);
             }
@@ -119,8 +119,8 @@ namespace EntityFrameworkCore.Jet.Query.ExpressionTranslators.Internal
             // Jet LTRIM does not take arguments
             // _trimStartWithNoParam is only available since .NET Core 2.0 (or .NET Standard 2.1).
             if (Equals(method, _trimStartWithNoParam) ||
-                Equals(method, _trimStartWithChars) &&
-                (!arguments.Any() || (arguments[0] as SqlConstantExpression)?.Value == null || ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0))
+                Equals(method, _trimStartWithChars) && ((arguments[0] as SqlConstantExpression)?.Value == null ||
+                 ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0))
             {
                 return _sqlExpressionFactory.Function("LTRIM", new[] {instance}, method.ReturnType);
             }
@@ -128,8 +128,8 @@ namespace EntityFrameworkCore.Jet.Query.ExpressionTranslators.Internal
             // Jet RTRIM does not take arguments
             // _trimEndWithNoParam is only available since .NET Core 2.0 (or .NET Standard 2.1).
             if (Equals(method, _trimEndWithNoParam) ||
-                Equals(method, _trimEndWithChars) &&
-                (!arguments.Any() || (arguments[0] as SqlConstantExpression)?.Value == null || ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0))
+                Equals(method, _trimEndWithChars) && ((arguments[0] as SqlConstantExpression)?.Value == null ||
+                 ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0))
             {
                 return _sqlExpressionFactory.Function("RTRIM", new[] {instance}, method.ReturnType);
             }

--- a/src/EFCore.Jet/Query/ExpressionTranslators/Internal/JetStringMethodTranslator.cs
+++ b/src/EFCore.Jet/Query/ExpressionTranslators/Internal/JetStringMethodTranslator.cs
@@ -111,7 +111,7 @@ namespace EntityFrameworkCore.Jet.Query.ExpressionTranslators.Internal
             // _trimWithNoParam is only available since .NET Core 2.0 (or .NET Standard 2.1).
             if (Equals(method, _trimWithNoParam) ||
                 Equals(method, _trimWithChars) &&
-                (arguments[0] as SqlConstantExpression)?.Value == null || ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0)
+                (!arguments.Any() || (arguments[0] as SqlConstantExpression)?.Value == null || ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0))
             {
                 return _sqlExpressionFactory.Function("TRIM", new[] {instance}, method.ReturnType);
             }
@@ -120,7 +120,7 @@ namespace EntityFrameworkCore.Jet.Query.ExpressionTranslators.Internal
             // _trimStartWithNoParam is only available since .NET Core 2.0 (or .NET Standard 2.1).
             if (Equals(method, _trimStartWithNoParam) ||
                 Equals(method, _trimStartWithChars) &&
-                (arguments[0] as SqlConstantExpression)?.Value == null || ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0)
+                (!arguments.Any() || (arguments[0] as SqlConstantExpression)?.Value == null || ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0))
             {
                 return _sqlExpressionFactory.Function("LTRIM", new[] {instance}, method.ReturnType);
             }
@@ -129,7 +129,7 @@ namespace EntityFrameworkCore.Jet.Query.ExpressionTranslators.Internal
             // _trimEndWithNoParam is only available since .NET Core 2.0 (or .NET Standard 2.1).
             if (Equals(method, _trimEndWithNoParam) ||
                 Equals(method, _trimEndWithChars) &&
-                (arguments[0] as SqlConstantExpression)?.Value == null || ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0)
+                (!arguments.Any() || (arguments[0] as SqlConstantExpression)?.Value == null || ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0))
             {
                 return _sqlExpressionFactory.Function("RTRIM", new[] {instance}, method.ReturnType);
             }

--- a/test/EFCore.Jet.FunctionalTests/Query/SimpleQueryJetTest.Functions.cs
+++ b/test/EFCore.Jet.FunctionalTests/Query/SimpleQueryJetTest.Functions.cs
@@ -847,7 +847,7 @@ WHERE (NEWID() <> '00000000-0000-0000-0000-000000000000') OR NEWID() IS NULL");
             AssertSql(
                 $@"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE UPPER(`c`.`CustomerID`) = 'ALFKI'");
+WHERE UCASE(`c`.`CustomerID`) = 'ALFKI'");
         }
 
         public override async Task Where_string_to_lower(bool isAsync)
@@ -857,7 +857,7 @@ WHERE UPPER(`c`.`CustomerID`) = 'ALFKI'");
             AssertSql(
                 $@"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE LOWER(`c`.`CustomerID`) = 'alfki'");
+WHERE LCASE(`c`.`CustomerID`) = 'alfki'");
         }
 
         public override async Task Where_functions_nested(bool isAsync)

--- a/test/EFCore.Jet.FunctionalTests/Query/SimpleQueryJetTest.Functions.cs
+++ b/test/EFCore.Jet.FunctionalTests/Query/SimpleQueryJetTest.Functions.cs
@@ -1413,7 +1413,7 @@ WHERE RTRIM(`c`.`ContactTitle`) = 'Owner'");
             AssertSql(
                 $@"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE LTRIM(RTRIM(`c`.`ContactTitle`)) = 'Owner'");
+WHERE TRIM(`c`.`ContactTitle`) = 'Owner'");
         }
 
         [ConditionalTheory(Skip = "Issue#17328")]


### PR DESCRIPTION
Version: alpha 4

When using toLower(), I was getting an IndexOutOfRange exception during query generation. When debugging the source, I found there was an issue in the JetStringMethodTranslator where the Trim clauses are formed. It checks if the passed arguments contain a null value on index 0, but it doesn't check if there actually is a value to begin with. That was the reason for the exception.

I've adjusted the clauses to now first do that check before attempting to access the arguments. 

I noticed a couple of tests failing with the same exception. After adding the fix, there was still an issue, where UPPER was expected in the generated query, while UCASE was used. The latter is the correct MS Access Function so I've adjusted the expected result both the upper and lower case test.

Fixes #78