### PR TITLE
Workaround an MDB Tools casing issue

### DIFF
--- a/test/EFCore.Jet.Data.Tests/ConnectionTest.cs
+++ b/test/EFCore.Jet.Data.Tests/ConnectionTest.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EntityFrameworkCore.Jet.Data.Tests
+{
+    [TestClass]
+    public class OdbcConnectionTest
+    {
+        private const string StoreName = nameof(OdbcConnectionTest) + ".accdb";
+
+        [TestInitialize]
+        public void Setup()
+        {
+            Helpers.CreateDatabase(StoreName);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            Helpers.DeleteDatabase(StoreName);
+        }
+
+        [TestMethod]
+        public void Open_odbc_connection_uppercase_dbq_mdbtools_workaround()
+        {
+            using var connection = new JetConnection(JetConnection.GetConnectionString(StoreName, DataAccessProviderType.Odbc));
+            connection.Open();
+
+            Assert.IsTrue(connection.ConnectionString.Contains("DBQ=", StringComparison.Ordinal));
+        }
+   }
+}


### PR DESCRIPTION
[MDB Tools](https://github.com/mdbtools/mdbtools) contains a [bug](https://github.com/mdbtools/mdbtools/blob/1efb1054d3573afb1859b7cef88789a335547e70/src/odbc/connectparams.c), that case sensitively checks for the `DBQ` and `DSN` connection string options and expects them to be UPPERCASE. However, `OdbcConnectionStringBuilder` returns them lower case.

We therefore ensure for now, that those two options will always be UPPERCASE, before the connection is being opened by ODBC.
Ultimately, this issue needs to be fixed upstream in MDB Tools.

Fixes #76