### PR TITLE
Fix DateTime fractions logic and make milliseconds support opt-in

### DIFF
--- a/src/EFCore.Jet/Infrastructure/Internal/IJetOptions.cs
+++ b/src/EFCore.Jet/Infrastructure/Internal/IJetOptions.cs
@@ -14,5 +14,6 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
         string ConnectionString { get; }
         DataAccessProviderType DataAccessProviderType { get; }
         bool UseOuterSelectSkipEmulationViaDataReader { get; }
+        bool EnableMillisecondsSupport { get; }
     }
 }

--- a/src/EFCore.Jet/Infrastructure/Internal/JetOptionsExtension.cs
+++ b/src/EFCore.Jet/Infrastructure/Internal/JetOptionsExtension.cs
@@ -23,6 +23,7 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
         // private bool? _rowNumberPaging;
         private DbProviderFactory _dataAccessProviderFactory;
         private bool _useOuterSelectSkipEmulationViaDataReader;
+        private bool _enableMillisecondsSupport;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -48,6 +49,7 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
             // _rowNumberPaging = copyFrom._rowNumberPaging;
             _dataAccessProviderFactory = copyFrom._dataAccessProviderFactory;
             _useOuterSelectSkipEmulationViaDataReader = copyFrom._useOuterSelectSkipEmulationViaDataReader;
+            _enableMillisecondsSupport = copyFrom._enableMillisecondsSupport;
         }
 
         /// <summary>
@@ -145,6 +147,29 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual bool EnableMillisecondsSupport => _enableMillisecondsSupport;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual JetOptionsExtension WithEnableMillisecondsSupport(bool enabled)
+        {
+            var clone = (JetOptionsExtension) Clone();
+
+            clone._enableMillisecondsSupport = enabled;
+
+            return clone;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public override void ApplyServices(IServiceCollection services)
             => services.AddEntityFrameworkJet();
 
@@ -190,6 +215,11 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
                             builder.Append("UseOuterSelectSkipEmulationViaDataReader ");
                         }
 
+                        if (Extension._enableMillisecondsSupport)
+                        {
+                            builder.Append("EnableMillisecondsSupport ");
+                        }
+
                         _logFragment = builder.ToString();
                     }
 
@@ -203,7 +233,8 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
                 {
                     _serviceProviderHash = (base.GetServiceProviderHashCode() * 397) ^
                                            (Extension._dataAccessProviderFactory?.GetHashCode() ?? 0L) ^
-                                           (Extension._useOuterSelectSkipEmulationViaDataReader.GetHashCode() * 397) /* ^
+                                           (Extension._useOuterSelectSkipEmulationViaDataReader.GetHashCode() * 397) ^
+                                           (Extension._enableMillisecondsSupport.GetHashCode() * 397)/* ^
                                            (Extension._rowNumberPaging?.GetHashCode() ?? 0L)*/;
                 }
 
@@ -222,6 +253,8 @@ namespace EntityFrameworkCore.Jet.Infrastructure.Internal
                 debugInfo["Jet:" + nameof(JetDbContextOptionsBuilder.UseOuterSelectSkipEmulationViaDataReader)]
 #pragma warning restore 618
                     = Extension._useOuterSelectSkipEmulationViaDataReader.GetHashCode().ToString(CultureInfo.InvariantCulture);
+                debugInfo["Jet:" + nameof(JetDbContextOptionsBuilder.EnableMillisecondsSupport)]
+                    = Extension._enableMillisecondsSupport.GetHashCode().ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/EFCore.Jet/Infrastructure/JetDbContextOptionsBuilder.cs
+++ b/src/EFCore.Jet/Infrastructure/JetDbContextOptionsBuilder.cs
@@ -48,6 +48,13 @@ namespace EntityFrameworkCore.Jet.Infrastructure
             => WithOption(e => e.WithUseOuterSelectSkipEmulationViaDataReader(enabled));
 
         /// <summary>
+        ///     Configures the context support milliseconds in `DateTime`, `DateTimeOffset` and `TimeSpan` values when
+        ///     accessing Jet databases. Jet has no native support for milliseconds, therefore this feature is opt-in.
+        /// </summary>
+        public virtual JetDbContextOptionsBuilder EnableMillisecondsSupport(bool enabled = true)
+            => WithOption(e => e.WithEnableMillisecondsSupport(enabled));
+
+        /// <summary>
         ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
         /// </summary>
         public virtual JetDbContextOptionsBuilder EnableRetryOnFailure()

--- a/src/EFCore.Jet/Internal/JetOptions.cs
+++ b/src/EFCore.Jet/Internal/JetOptions.cs
@@ -28,6 +28,7 @@ namespace EntityFrameworkCore.Jet.Internal
             
             DataAccessProviderType = GetDataAccessProviderTypeFromOptions(jetOptions);
             UseOuterSelectSkipEmulationViaDataReader = jetOptions.UseOuterSelectSkipEmulationViaDataReader;
+            EnableMillisecondsSupport = jetOptions.EnableMillisecondsSupport;
             ConnectionString = jetOptions.Connection?.ConnectionString ?? jetOptions.ConnectionString;
         }
 
@@ -62,6 +63,14 @@ namespace EntityFrameworkCore.Jet.Internal
                 throw new InvalidOperationException(
                     CoreStrings.SingletonOptionChanged(
                         nameof(JetOptionsExtension.UseOuterSelectSkipEmulationViaDataReader),
+                        nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
+            }
+
+            if (EnableMillisecondsSupport != jetOptions.EnableMillisecondsSupport)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.SingletonOptionChanged(
+                        nameof(JetOptionsExtension.EnableMillisecondsSupport),
                         nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
             }
         }
@@ -124,6 +133,14 @@ namespace EntityFrameworkCore.Jet.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual bool UseOuterSelectSkipEmulationViaDataReader { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public bool EnableMillisecondsSupport { get; private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Jet/Migrations/JetMigrationsSqlGenerator.cs
+++ b/src/EFCore.Jet/Migrations/JetMigrationsSqlGenerator.cs
@@ -773,7 +773,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 }
 
                 defaultValue = defaultValue.GetType().IsTimeRelatedType()
-                    ? JetDateTimeTypeMapping.GenerateNonNullSqlLiteral(defaultValue, true)
+                    ? JetDateTimeTypeMapping.GenerateNonNullSqlLiteral(defaultValue, true, _options.EnableMillisecondsSupport)
                     : typeMapping.GenerateSqlLiteral(defaultValue);
                 
                 builder

--- a/src/EFCore.Jet/Query/Internal/JetQueryTranslationPostprocessor.cs
+++ b/src/EFCore.Jet/Query/Internal/JetQueryTranslationPostprocessor.cs
@@ -1,18 +1,23 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq.Expressions;
+using EntityFrameworkCore.Jet.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace EntityFrameworkCore.Jet.Query.Internal
 {
     public class JetQueryTranslationPostprocessor : RelationalQueryTranslationPostprocessor
     {
+        private readonly IJetOptions _options;
+
         public JetQueryTranslationPostprocessor(
             QueryTranslationPostprocessorDependencies dependencies,
             RelationalQueryTranslationPostprocessorDependencies relationalDependencies,
-            QueryCompilationContext queryCompilationContext)
+            QueryCompilationContext queryCompilationContext,
+            IJetOptions options)
             : base(dependencies, relationalDependencies, queryCompilationContext)
         {
+            _options = options;
         }
 
         public override Expression Process(Expression query)
@@ -20,7 +25,11 @@ namespace EntityFrameworkCore.Jet.Query.Internal
             query = base.Process(query);
             
             query = new SearchConditionConvertingExpressionVisitor(SqlExpressionFactory).Visit(query);
-            query = new JetDateTimeExpressionVisitor(SqlExpressionFactory).Visit(query);
+
+            if (_options.EnableMillisecondsSupport)
+            {
+                query = new JetDateTimeExpressionVisitor(SqlExpressionFactory).Visit(query);
+            }
 
             return query;
         }

--- a/src/EFCore.Jet/Query/Internal/JetQueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore.Jet/Query/Internal/JetQueryTranslationPostprocessorFactory.cs
@@ -1,5 +1,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using EntityFrameworkCore.Jet.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,19 +23,23 @@ namespace EntityFrameworkCore.Jet.Query.Internal
     {
         private readonly QueryTranslationPostprocessorDependencies _dependencies;
         private readonly RelationalQueryTranslationPostprocessorDependencies _relationalDependencies;
+        private readonly IJetOptions _options;
 
         public JetQueryTranslationPostprocessorFactory(
             QueryTranslationPostprocessorDependencies dependencies,
-            RelationalQueryTranslationPostprocessorDependencies relationalDependencies)
+            RelationalQueryTranslationPostprocessorDependencies relationalDependencies,
+            IJetOptions options)
         {
             _dependencies = dependencies;
             _relationalDependencies = relationalDependencies;
+            _options = options;
         }
 
         public virtual QueryTranslationPostprocessor Create(QueryCompilationContext queryCompilationContext)
             => new JetQueryTranslationPostprocessor(
                 _dependencies,
                 _relationalDependencies,
-                queryCompilationContext);
+                queryCompilationContext,
+                _options);
     }
 }

--- a/src/EFCore.Jet/Storage/Internal/JetDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDateTimeOffsetTypeMapping.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Data.Common;
+using EntityFrameworkCore.Jet.Infrastructure.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -9,24 +10,29 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
 {
     public class JetDateTimeOffsetTypeMapping : JetDateTimeTypeMapping
     {
+        private readonly IJetOptions _options;
+
         public JetDateTimeOffsetTypeMapping(
-                [NotNull] string storeType)
+                [NotNull] string storeType,
+                [NotNull] IJetOptions options)
             : base(
                 storeType,
+                options,
                 System.Data.DbType.DateTime,
                 typeof(DateTimeOffset)) // delibrately use DbType.DateTime, because OleDb will throw a
                                         // "No mapping exists from DbType DateTimeOffset to a known OleDbType."
                                         // exception when using DbType.DateTimeOffset.
         {
+            _options = options;
         }
 
-        protected JetDateTimeOffsetTypeMapping(RelationalTypeMappingParameters parameters)
-            : base(parameters)
+        protected JetDateTimeOffsetTypeMapping(RelationalTypeMappingParameters parameters, IJetOptions options)
+            : base(parameters, options)
         {
         }
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new JetDateTimeOffsetTypeMapping(parameters);
+            => new JetDateTimeOffsetTypeMapping(parameters, _options);
 
         protected override void ConfigureParameter(DbParameter parameter)
         {

--- a/src/EFCore.Jet/Storage/Internal/JetDateTimeTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDateTimeTypeMapping.cs
@@ -102,14 +102,14 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
             {
                 // Round to milliseconds.
                 var millisecondsTicks = checkDateTimeValue.Ticks / TimeSpan.TicksPerMillisecond * TimeSpan.TicksPerMillisecond;
-                var result = Math.Round((decimal) millisecondsTicks / TimeSpan.TicksPerDay, MaxDateTimeDoublePrecision);
+                var result = /*Math.Round(*/(decimal) millisecondsTicks / TimeSpan.TicksPerDay/*, MaxDateTimeDoublePrecision, MidpointRounding.AwayFromZero)*/;
                 return result;
             }
             else
             {
                 // Round to seconds.
                 var secondsTicks = checkDateTimeValue.Ticks / TimeSpan.TicksPerSecond * TimeSpan.TicksPerSecond;
-                var result = Math.Round((decimal) secondsTicks / TimeSpan.TicksPerDay, MaxDateTimeDoublePrecision - 2);
+                var result = /*Math.Round(*/(decimal) secondsTicks / TimeSpan.TicksPerDay/*, MaxDateTimeDoublePrecision, MidpointRounding.AwayFromZero)*/;
                 return result;
             }
         }

--- a/src/EFCore.Jet/Storage/Internal/JetDateTimeTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDateTimeTypeMapping.cs
@@ -46,6 +46,9 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
             {
                 parameter.Value = GetDateTimeDoubleValueAsDecimal(dateTime, _options.EnableMillisecondsSupport);
                 parameter.ResetDbType();
+                
+                // Necessary to explicitly set for OLE DB, to apply the System.Decimal value as DOUBLE to Jet.
+                parameter.DbType = System.Data.DbType.Double;
             }
         }
 
@@ -96,6 +99,10 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
 
         private static decimal GetDateTimeDoubleValueAsDecimal(DateTime dateTime, bool millisecondsSupportEnabled)
         {
+            //
+            // We are explicitly using System.Decimal here, so we get better scale results:
+            //
+            
             var checkDateTimeValue = CheckDateTimeValue(dateTime) - JetConfiguration.TimeSpanOffset;
 
             if (millisecondsSupportEnabled)

--- a/src/EFCore.Jet/Storage/Internal/JetDateTimeTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDateTimeTypeMapping.cs
@@ -6,6 +6,7 @@ using System.Data.Common;
 using System.Globalization;
 using System.Text;
 using EntityFrameworkCore.Jet.Data;
+using EntityFrameworkCore.Jet.Infrastructure.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -15,88 +16,102 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
     {
         private const int MaxDateTimeDoublePrecision = 10;
         private static readonly JetDecimalTypeMapping _decimalTypeMapping = new JetDecimalTypeMapping("decimal", System.Data.DbType.Decimal, 18, 10);
-        
+        private readonly IJetOptions _options;
+
         public JetDateTimeTypeMapping(
             [NotNull] string storeType,
+            [NotNull] IJetOptions options,
             DbType? dbType = null,
             [CanBeNull] Type clrType = null)
             : base(storeType, clrType ?? typeof(DateTime), dbType ?? System.Data.DbType.DateTime)
         {
+            _options = options;
         }
 
-        protected JetDateTimeTypeMapping(RelationalTypeMappingParameters parameters)
+        protected JetDateTimeTypeMapping(RelationalTypeMappingParameters parameters, IJetOptions options)
             : base(parameters)
         {
+            _options = options;
         }
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new JetDateTimeTypeMapping(parameters);
+            => new JetDateTimeTypeMapping(parameters, _options);
 
         protected override void ConfigureParameter(DbParameter parameter)
         {
             base.ConfigureParameter(parameter);
             
-            if (parameter.Value is DateTime dateTime)
+            if (_options.EnableMillisecondsSupport &&
+                parameter.Value is DateTime dateTime)
             {
-                parameter.Value = GetDateTimeDoubleValueAsDecimal(dateTime);
+                parameter.Value = GetDateTimeDoubleValueAsDecimal(dateTime, _options.EnableMillisecondsSupport);
                 parameter.ResetDbType();
             }
         }
 
         protected override string GenerateNonNullSqlLiteral(object value)
-            => GenerateNonNullSqlLiteral(value, false);
+            => GenerateNonNullSqlLiteral(value, false, _options.EnableMillisecondsSupport);
 
-        public static string GenerateNonNullSqlLiteral(object value, bool defaultClauseCompatible)
+        public static string GenerateNonNullSqlLiteral(object value, bool defaultClauseCompatible, bool millisecondsSupportEnabled)
         {
             var dateTime = (DateTime) value;
 
             dateTime = CheckDateTimeValue(dateTime);
-            
-            if (!defaultClauseCompatible /*&&
-                dateTime.Ticks % TimeSpan.TicksPerSecond == 0*/)
+
+            if (defaultClauseCompatible)
             {
-                var literal = new StringBuilder()
-                    .AppendFormat(CultureInfo.InvariantCulture, "#{0:yyyy-MM-dd}", dateTime);
+                return _decimalTypeMapping.GenerateSqlLiteral(GetDateTimeDoubleValueAsDecimal(dateTime, millisecondsSupportEnabled));
+            }
+            
+            var literal = new StringBuilder()
+                .AppendFormat(CultureInfo.InvariantCulture, "#{0:yyyy-MM-dd}", dateTime);
                 
-                var time = dateTime.TimeOfDay;
-                if (time != TimeSpan.Zero)
-                {
-                    literal.AppendFormat(CultureInfo.InvariantCulture, @" {0:hh\:mm\:ss}", time);
-                }
-
-                literal.Append("#");
-                
-                if (time != TimeSpan.Zero)
-                {
-                    // Round to milliseconds.
-                    var millisecondsTicks = time.Ticks % TimeSpan.TicksPerSecond / TimeSpan.TicksPerMillisecond * TimeSpan.TicksPerMillisecond;
-                    if (millisecondsTicks > 0)
-                    {
-                        var jetTimeDoubleFractions = Math.Round((decimal) millisecondsTicks / TimeSpan.TicksPerDay, MaxDateTimeDoublePrecision);
-
-                        literal
-                            .Insert(0, "(")
-                            .Append(" + ")
-                            .Append(_decimalTypeMapping.GenerateSqlLiteral(jetTimeDoubleFractions))
-                            .Append(")");
-                    }
-                }
-
-                return literal.ToString();
+            var time = dateTime.TimeOfDay;
+            if (time != TimeSpan.Zero)
+            {
+                literal.AppendFormat(CultureInfo.InvariantCulture, @" {0:hh\:mm\:ss}", time);
             }
 
-            return _decimalTypeMapping.GenerateSqlLiteral(GetDateTimeDoubleValueAsDecimal(dateTime));
+            literal.Append("#");
+                
+            if (millisecondsSupportEnabled &&
+                time != TimeSpan.Zero)
+            {
+                // Round to milliseconds.
+                var millisecondsTicks = time.Ticks % TimeSpan.TicksPerSecond / TimeSpan.TicksPerMillisecond * TimeSpan.TicksPerMillisecond;
+                if (millisecondsTicks > 0)
+                {
+                    var jetTimeDoubleFractions = Math.Round((decimal) millisecondsTicks / TimeSpan.TicksPerDay, MaxDateTimeDoublePrecision);
+
+                    literal
+                        .Insert(0, "(")
+                        .Append(" + ")
+                        .Append(_decimalTypeMapping.GenerateSqlLiteral(jetTimeDoubleFractions))
+                        .Append(")");
+                }
+            }
+
+            return literal.ToString();
         }
 
-        private static decimal GetDateTimeDoubleValueAsDecimal(DateTime dateTime)
+        private static decimal GetDateTimeDoubleValueAsDecimal(DateTime dateTime, bool millisecondsSupportEnabled)
         {
             var checkDateTimeValue = CheckDateTimeValue(dateTime) - JetConfiguration.TimeSpanOffset;
-            
-            // Round to milliseconds.
-            var millisecondsTicks = checkDateTimeValue.Ticks / TimeSpan.TicksPerMillisecond * TimeSpan.TicksPerMillisecond;
-            var result = Math.Round((decimal) millisecondsTicks / TimeSpan.TicksPerDay, MaxDateTimeDoublePrecision);
 
-            return result;
+            if (millisecondsSupportEnabled)
+            {
+                // Round to milliseconds.
+                var millisecondsTicks = checkDateTimeValue.Ticks / TimeSpan.TicksPerMillisecond * TimeSpan.TicksPerMillisecond;
+                var result = Math.Round((decimal) millisecondsTicks / TimeSpan.TicksPerDay, MaxDateTimeDoublePrecision);
+                return result;
+            }
+            else
+            {
+                // Round to seconds.
+                var secondsTicks = checkDateTimeValue.Ticks / TimeSpan.TicksPerSecond * TimeSpan.TicksPerSecond;
+                var result = Math.Round((decimal) secondsTicks / TimeSpan.TicksPerDay, MaxDateTimeDoublePrecision - 2);
+                return result;
+            }
         }
 
         private static DateTime CheckDateTimeValue(DateTime dateTime)

--- a/src/EFCore.Jet/Storage/Internal/JetTimeSpanTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetTimeSpanTypeMapping.cs
@@ -2,6 +2,7 @@
 
 using System;
 using EntityFrameworkCore.Jet.Data;
+using EntityFrameworkCore.Jet.Infrastructure.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -9,19 +10,23 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
 {
     public class JetTimeSpanTypeMapping : JetDateTimeTypeMapping
     {
+        [NotNull] private readonly IJetOptions _options;
+
         public JetTimeSpanTypeMapping(
-                [NotNull] string storeType)
-            : base(storeType, System.Data.DbType.Time, typeof(TimeSpan))
+                [NotNull] string storeType,
+                [NotNull] IJetOptions options)
+            : base(storeType, options, System.Data.DbType.Time, typeof(TimeSpan))
         {
+            _options = options;
         }
 
-        protected JetTimeSpanTypeMapping(RelationalTypeMappingParameters parameters)
-            : base(parameters)
+        protected JetTimeSpanTypeMapping(RelationalTypeMappingParameters parameters, IJetOptions options)
+            : base(parameters, options)
         {
         }
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new JetTimeSpanTypeMapping(parameters);
+            => new JetTimeSpanTypeMapping(parameters, _options);
         
         protected override string GenerateNonNullSqlLiteral(object value)
             => base.GenerateNonNullSqlLiteral(JetConfiguration.TimeSpanOffset + (TimeSpan) value);

--- a/src/EFCore.Jet/Storage/Internal/JetTypeMappingSource.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetTypeMappingSource.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using EntityFrameworkCore.Jet.Infrastructure.Internal;
 using EntityFrameworkCore.Jet.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -36,10 +37,10 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
         private readonly JetDecimalTypeMapping _decimal = new JetDecimalTypeMapping("decimal", DbType.Decimal, precision: 18, scale: 10, StoreTypePostfix.PrecisionAndScale);
         private readonly JetCurrencyTypeMapping _currency = new JetCurrencyTypeMapping("currency");
 
-        private readonly JetDateTimeTypeMapping _datetime = new JetDateTimeTypeMapping("datetime", dbType: DbType.DateTime);
-        private readonly JetDateTimeOffsetTypeMapping _datetimeoffset = new JetDateTimeOffsetTypeMapping("datetime");
-        private readonly JetDateTimeTypeMapping _date = new JetDateTimeTypeMapping("datetime", dbType: DbType.Date);
-        private readonly JetTimeSpanTypeMapping _time = new JetTimeSpanTypeMapping("datetime");
+        private readonly JetDateTimeTypeMapping _datetime;
+        private readonly JetDateTimeOffsetTypeMapping _datetimeoffset;
+        private readonly JetDateTimeTypeMapping _date;
+        private readonly JetTimeSpanTypeMapping _time;
 
         private readonly JetStringTypeMapping _fixedLengthUnicodeString = new JetStringTypeMapping("char", unicode: true);
         private readonly JetStringTypeMapping _variableLengthUnicodeString = new JetStringTypeMapping("varchar", unicode: true);
@@ -58,7 +59,8 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
         /// </summary>
         public JetTypeMappingSource(
             [NotNull] TypeMappingSourceDependencies dependencies,
-            [NotNull] RelationalTypeMappingSourceDependencies relationalDependencies)
+            [NotNull] RelationalTypeMappingSourceDependencies relationalDependencies,
+            [NotNull] IJetOptions options)
             : base(dependencies, relationalDependencies)
         {
             // References:
@@ -70,6 +72,11 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
             // TODO: Check the types and their mappings against
             //       https://docs.microsoft.com/en-us/previous-versions/office/developer/office2000/aa140015(v=office.10)
             
+            _datetime = new JetDateTimeTypeMapping("datetime", options, dbType: DbType.DateTime);
+            _datetimeoffset = new JetDateTimeOffsetTypeMapping("datetime", options);
+            _date = new JetDateTimeTypeMapping("datetime", options, dbType: DbType.Date);
+            _time = new JetTimeSpanTypeMapping("datetime", options);
+
             _storeTypeMappings
                 = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
                 {

--- a/test/EFCore.Jet.FunctionalTests/EFCore.Jet.FunctionalTests.csproj
+++ b/test/EFCore.Jet.FunctionalTests/EFCore.Jet.FunctionalTests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="xunit.core" />
     <PackageReference Include="xunit.assert" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/test/EFCore.Jet.FunctionalTests/Query/SimpleQueryJetTest.Where.cs
+++ b/test/EFCore.Jet.FunctionalTests/Query/SimpleQueryJetTest.Where.cs
@@ -1519,7 +1519,7 @@ FROM `Customers` AS `c`");
             AssertSql(
                 $@"SELECT `o`.`OrderID`, `o`.`CustomerID`, `o`.`EmployeeID`, `o`.`OrderDate`
 FROM `Orders` AS `o`
-WHERE (`o`.`CustomerID` = 'QUICK') AND (`o`.`OrderDate` > #1998-01-01 00:00:00#)");
+WHERE (`o`.`CustomerID` = 'QUICK') AND (`o`.`OrderDate` > #1998-01-01#)");
         }
 
         public override void Where_navigation_contains()

--- a/test/EFCore.Jet.FunctionalTests/Query/SimpleQueryJetTest.cs
+++ b/test/EFCore.Jet.FunctionalTests/Query/SimpleQueryJetTest.cs
@@ -1667,7 +1667,7 @@ FROM `Customers` AS `c`
 WHERE (`c`.`CustomerID` = 'ALFKI') AND EXISTS (
     SELECT 1
     FROM `Orders` AS `o`
-    WHERE (`c`.`CustomerID` = `o`.`CustomerID`) AND (`o`.`OrderDate` = #2008-10-24 00:00:00#))");
+    WHERE (`c`.`CustomerID` = `o`.`CustomerID`) AND (`o`.`OrderDate` = #2008-10-24#))");
         }
 
         public override async Task Where_Join_Exists(bool isAsync)

--- a/test/EFCore.Jet.FunctionalTests/TestUtilities/Xunit/AscendingTestCaseOrderer.cs
+++ b/test/EFCore.Jet.FunctionalTests/TestUtilities/Xunit/AscendingTestCaseOrderer.cs
@@ -1,14 +1,16 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace EntityFrameworkCore.Jet.FunctionalTests.TestUtilities.TestCaseOrderers
+// ReSharper disable once CheckNamespace
+namespace EntityFrameworkCore.Jet.FunctionalTests.TestUtilities.Xunit
 {
     public class AscendingTestCaseOrderer : ITestCaseOrderer
     {
         public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
             where TTestCase : ITestCase
-            => testCases.OrderBy(c => c.DisplayName);
+            => testCases.OrderBy(c => c.DisplayName, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/test/EFCore.Jet.FunctionalTests/TestUtilities/Xunit/AscendingTestCollectionOrderer.cs
+++ b/test/EFCore.Jet.FunctionalTests/TestUtilities/Xunit/AscendingTestCollectionOrderer.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+// ReSharper disable once CheckNamespace
+namespace EntityFrameworkCore.Jet.FunctionalTests.TestUtilities.Xunit
+{
+    public class AscendingTestCollectionOrderer : ITestCollectionOrderer
+    {
+        public IEnumerable<ITestCollection> OrderTestCollections(IEnumerable<ITestCollection> testCollections)
+            => testCollections.OrderBy(c => c.DisplayName, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/test/EFCore.Jet.FunctionalTests/TestUtilities/Xunit/ExceptionTestCaseOrderer.cs
+++ b/test/EFCore.Jet.FunctionalTests/TestUtilities/Xunit/ExceptionTestCaseOrderer.cs
@@ -7,7 +7,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace EntityFrameworkCore.Jet.FunctionalTests.TestUtilities.TestCaseOrderers
+// ReSharper disable once CheckNamespace
+namespace EntityFrameworkCore.Jet.FunctionalTests.TestUtilities.Xunit
 {
     public class ExceptionTestCaseOrderer : ITestCaseOrderer
     {

--- a/test/EFCore.Jet.FunctionalTests/TestUtilities/Xunit/RandomTestCaseOrderer.cs
+++ b/test/EFCore.Jet.FunctionalTests/TestUtilities/Xunit/RandomTestCaseOrderer.cs
@@ -6,7 +6,8 @@ using System.Text;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace EntityFrameworkCore.Jet.FunctionalTests.TestUtilities.TestCaseOrderers
+// ReSharper disable once CheckNamespace
+namespace EntityFrameworkCore.Jet.FunctionalTests.TestUtilities.Xunit
 {
     public class RandomTestCaseOrderer : ITestCaseOrderer
     {

--- a/test/EFCore.Jet.Tests/EFCore.Jet.Tests.csproj
+++ b/test/EFCore.Jet.Tests/EFCore.Jet.Tests.csproj
@@ -5,6 +5,10 @@
     <AssemblyName>EntityFrameworkCore.Jet.Tests</AssemblyName>
     <RootNamespace>EntityFrameworkCore.Jet</RootNamespace>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Include="..\Shared\**\*.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Update="config.json">

--- a/test/EFCore.Jet.Tests/JetDateTimeTest.cs
+++ b/test/EFCore.Jet.Tests/JetDateTimeTest.cs
@@ -33,6 +33,20 @@ namespace EntityFrameworkCore.Jet
                 .ToList();
             
             Assert.Equal(2, cookies.Count);
+            Assert.True(cookies.All(c => c.BestServedBeforeDateTime == new DateTime(2021, 12, 31, 13, 42, 21)));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetime_with_HasDefaultValue_EnableMillisecondsSupport()
+        {
+            using var context = CreateContext(jetOptions: builder => builder.EnableMillisecondsSupport());
+            context.Database.EnsureCreatedResiliently();
+
+            var cookies = context.Cookies
+                .Where(o => o.BestServedBeforeDateTime == new DateTime(2021, 12, 31, 13, 42, 21, 123))
+                .ToList();
+            
+            Assert.Equal(2, cookies.Count);
             Assert.True(cookies.All(c => c.BestServedBeforeDateTime == new DateTime(2021, 12, 31, 13, 42, 21, 123)));
         }
 
@@ -43,7 +57,21 @@ namespace EntityFrameworkCore.Jet
             context.Database.EnsureCreatedResiliently();
 
             var cookies = context.Cookies
-                .Where(o => o.BestServedBeforeDateTime == new DateTime(2021, 12, 31, 13, 42, 21, 124))
+                .Where(o => o.BestServedBeforeDateTime == new DateTime(2021, 12, 31, 13, 42, 21, 987))
+                .ToList();
+            
+            Assert.Equal(2, cookies.Count);
+            Assert.True(cookies.All(c => c.BestServedBeforeDateTime == new DateTime(2021, 12, 31, 13, 42, 21)));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetime_with_HasDefaultValue_precision_EnableMillisecondsSupport()
+        {
+            using var context = CreateContext(jetOptions: builder => builder.EnableMillisecondsSupport());
+            context.Database.EnsureCreatedResiliently();
+
+            var cookies = context.Cookies
+                .Where(o => o.BestServedBeforeDateTime == new DateTime(2021, 12, 31, 13, 42, 21, 987))
                 .ToList();
             
             Assert.Empty(cookies);
@@ -53,6 +81,20 @@ namespace EntityFrameworkCore.Jet
         public virtual void Where_datetime_with_HasDefaultValueSql()
         {
             using var context = CreateContext();
+            context.Database.EnsureCreatedResiliently();
+
+            var cookies = context.Cookies
+                .Where(o => o.BestServedAfterDateTime == new DateTime(2020, 12, 31, 13, 42, 21))
+                .ToList();
+            
+            Assert.Equal(2, cookies.Count);
+            Assert.True(cookies.All(c => c.BestServedAfterDateTime == new DateTime(2020, 12, 31, 13, 42, 21)));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetime_with_HasDefaultValueSql_EnableMillisecondsSupport()
+        {
+            using var context = CreateContext(jetOptions: builder => builder.EnableMillisecondsSupport());
             context.Database.EnsureCreatedResiliently();
 
             var cookies = context.Cookies
@@ -74,13 +116,41 @@ namespace EntityFrameworkCore.Jet
                 .ToList();
             
             Assert.Single(cookies);
+            Assert.Equal(new DateTime(2019, 12, 31, 13, 42, 21), cookies[0].PuchasedDateTime);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetime_with_fractions_EnableMillisecondsSupport()
+        {
+            using var context = CreateContext(jetOptions: builder => builder.EnableMillisecondsSupport());
+            context.Database.EnsureCreatedResiliently();
+
+            var cookies = context.Cookies
+                .Where(o => o.PuchasedDateTime == new DateTime(2019, 12, 31, 13, 42, 21, 123))
+                .ToList();
+            
+            Assert.Single(cookies);
             Assert.Equal(new DateTime(2019, 12, 31, 13, 42, 21, 123), cookies[0].PuchasedDateTime);
         }
-        
+
         [ConditionalFact]
         public virtual void Where_datetime_with_fractions_paramter()
         {
             using var context = CreateContext();
+
+            var dateTime = new DateTime(2019, 12, 31, 13, 42, 21, 123);
+            var cookies = context.Cookies
+                .Where(o => o.PuchasedDateTime == dateTime)
+                .ToList();
+            
+            Assert.Single(cookies);
+            Assert.Equal(new DateTime(2019, 12, 31, 13, 42, 21), cookies[0].PuchasedDateTime);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetime_with_fractions_paramter_EnableMillisecondsSupport()
+        {
+            using var context = CreateContext(jetOptions: builder => builder.EnableMillisecondsSupport());
 
             var dateTime = new DateTime(2019, 12, 31, 13, 42, 21, 123);
             var cookies = context.Cookies

--- a/test/EFCore.Jet.Tests/JetDateTimeTest.cs
+++ b/test/EFCore.Jet.Tests/JetDateTimeTest.cs
@@ -134,7 +134,7 @@ namespace EntityFrameworkCore.Jet
         }
 
         [ConditionalFact]
-        public virtual void Where_datetime_with_fractions_paramter()
+        public virtual void Where_datetime_with_fractions_parameter()
         {
             using var context = CreateContext();
 
@@ -148,7 +148,7 @@ namespace EntityFrameworkCore.Jet
         }
 
         [ConditionalFact]
-        public virtual void Where_datetime_with_fractions_paramter_EnableMillisecondsSupport()
+        public virtual void Where_datetime_with_fractions_parameter_EnableMillisecondsSupport()
         {
             using var context = CreateContext(jetOptions: builder => builder.EnableMillisecondsSupport());
 

--- a/test/EFCore.Jet.Tests/JetMigrationTest.cs
+++ b/test/EFCore.Jet.Tests/JetMigrationTest.cs
@@ -11,7 +11,7 @@ namespace EntityFrameworkCore.Jet
         public virtual void Create_table_with_HasDefaultValueSql()
         {
             using var context = CreateContext(
-                builder =>
+                model: builder =>
                 {
                     builder.Entity<Cookie>(
                         entity =>

--- a/test/EFCore.Jet.Tests/Properties/AssemblyInfo.cs
+++ b/test/EFCore.Jet.Tests/Properties/AssemblyInfo.cs
@@ -1,12 +1,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using EntityFrameworkCore.Jet.FunctionalTests.TestUtilities;
 using EntityFrameworkCore.Jet.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 
 // Set assembly wide conditions to control tests in accordance with the environment they are run in.
-[assembly: JetConfiguredCondition]
-
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 [assembly: TestCollectionOrderer("EntityFrameworkCore.Jet.FunctionalTests.TestUtilities.Xunit." + nameof(AscendingTestCollectionOrderer), "EntityFrameworkCore.Jet.FunctionalTests")]
 [assembly: TestCaseOrderer("EntityFrameworkCore.Jet.FunctionalTests.TestUtilities.Xunit." + nameof(AscendingTestCaseOrderer), "EntityFrameworkCore.Jet.FunctionalTests")]

--- a/test/EFCore.Jet.Tests/TestBase.cs
+++ b/test/EFCore.Jet.Tests/TestBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using EntityFrameworkCore.Jet.FunctionalTests.TestUtilities;
+using EntityFrameworkCore.Jet.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.Jet
@@ -19,14 +20,19 @@ namespace EntityFrameworkCore.Jet
         public virtual List<string> SqlCommands { get; } = new List<string>();
         public virtual string Sql => string.Join("\n\n", SqlCommands);
 
-        public virtual TContext CreateContext(Action<ModelBuilder> modelBuilder = null)
+        public virtual TContext CreateContext(
+            Action<JetDbContextOptionsBuilder> jetOptions = null,
+            Action<IServiceProvider, DbContextOptionsBuilder> options = null,
+            Action<ModelBuilder> model = null)
         {
             var context = new TContext();
             
             context.Initialize(
                 TestStore.Name,
-                (command) => SqlCommands.Add(command.CommandText),
-                modelBuilder);
+                command => SqlCommands.Add(command.CommandText),
+                model: model,
+                options: options,
+                jetOptions: jetOptions);
 
             TestStore.Clean(context);
             


### PR DESCRIPTION
Makes the milliseconds support opt-in, because it is not clear if there are scenarios that could unexpected for users.
This also simplifies testing, because we don't have to change every single `AssertSql()` statement, that includes a `DateTime` column in its outer most `SELECT` statement.

To opt-in, use the `JetDbContextOptionsBuilder.EnableMillisecondsSupport()` method when calling `UseJet()`, `UseJetOdbc()` or `UseJetOleDb()`.