### PR TITLE
Fix CREATE/DROP DATABASE related issues

### DIFF
--- a/src/EFCore.Jet.Data/JetConnection.cs
+++ b/src/EFCore.Jet.Data/JetConnection.cs
@@ -210,9 +210,7 @@ namespace EntityFrameworkCore.Jet.Data
         /// </returns>
         protected override DbCommand CreateDbCommand()
         {
-            var command = JetFactory.CreateCommand();
-            command.Connection = this;
-            return command;
+            return CreateCommand(null);
         }
 
         /// <summary>

--- a/src/EFCore.Jet/Storage/Internal/JetDatabaseCreator.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDatabaseCreator.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using EntityFrameworkCore.Jet.Data;
 using EntityFrameworkCore.Jet.Internal;
 using EntityFrameworkCore.Jet.Migrations.Operations;
 using JetBrains.Annotations;
@@ -101,7 +102,17 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
             => _rawSqlCommandBuilder.Build(@"SELECT * FROM `INFORMATION_SCHEMA.TABLES` WHERE TABLE_TYPE IN ('BASE TABLE', 'VIEW')");
 
         private IReadOnlyList<MigrationCommand> CreateCreateOperations()
-            => Dependencies.MigrationsSqlGenerator.Generate(new[] {new JetCreateDatabaseOperation {Name = _relationalConnection.DbConnection.DataSource}});
+        {
+            var dataSource = _relationalConnection.DbConnection.DataSource;
+
+            // Alternative:
+            // var connection = (JetConnection) _relationalConnection.DbConnection;
+            // var csb = connection.JetFactory.CreateConnectionStringBuilder();
+            // csb.ConnectionString = connection.ConnectionString;
+            // var dataSource = csb.GetDataSource();
+            
+            return Dependencies.MigrationsSqlGenerator.Generate(new[] {new JetCreateDatabaseOperation {Name = dataSource}});
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.Jet.Data.Tests/ConnectionStringTest.cs
+++ b/test/EFCore.Jet.Data.Tests/ConnectionStringTest.cs
@@ -1,0 +1,47 @@
+﻿using System.Data.Odbc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EntityFrameworkCore.Jet.Data.Tests
+{
+    [TestClass]
+    public class ConnectionStringTest
+    {
+        [TestMethod]
+        public void Escape_double_quoted_connection_string()
+        {
+            var expectedDatabaseName = "Joe's \"Recipes\" Database.accdb";
+            var escapedDatabaseName = expectedDatabaseName.Replace("\"", "\"\"");
+            
+            var connectionString = Helpers.DataAccessProviderFactory is OdbcFactory
+                ? $"DBQ=\"{escapedDatabaseName}\""
+                : $"Data Source=\"{escapedDatabaseName}\"";
+
+            var csb = Helpers.DataAccessProviderFactory.CreateConnectionStringBuilder();
+            csb.ConnectionString = connectionString;
+            
+            var actualDatabaseName = csb.GetDataSource();
+            
+            Assert.AreEqual(expectedDatabaseName, actualDatabaseName);
+        }
+        
+        [TestMethod]
+        public void Escape_single_quoted_connection_string()
+        {
+            var expectedDatabaseName = "Joe's \"Recipes\" Database.accdb";
+            var escapedDatabaseName = expectedDatabaseName.Replace("'", "''");
+            
+            var connectionString = Helpers.DataAccessProviderFactory is OdbcFactory
+                ? $"DBQ='{escapedDatabaseName}'"
+                : $"Data Source='{escapedDatabaseName}'";
+
+            using var connection = new JetConnection(connectionString, Helpers.DataAccessProviderFactory);
+            
+            var csb = Helpers.DataAccessProviderFactory.CreateConnectionStringBuilder();
+            csb.ConnectionString = connectionString;
+            
+            var actualDatabaseName = csb.GetDataSource();
+            
+            Assert.AreEqual(expectedDatabaseName, actualDatabaseName);
+        }
+    }
+}

--- a/test/EFCore.Jet.Tests/TestBase.cs
+++ b/test/EFCore.Jet.Tests/TestBase.cs
@@ -11,11 +11,12 @@ namespace EntityFrameworkCore.Jet
     {
         public TestBase()
         {
-            TestStore = JetTestStore.CreateInitialized(nameof(JetMigrationTest));
+            TestStore = JetTestStore.CreateInitialized(StoreName);
         }
 
         public virtual void Dispose() => TestStore.Dispose();
 
+        public virtual string StoreName => GetType().Name;
         public virtual JetTestStore TestStore { get; }
         public virtual List<string> SqlCommands { get; } = new List<string>();
         public virtual string Sql => string.Join("\n\n", SqlCommands);


### PR DESCRIPTION
This fixes multiple issues in connection with the `CREATE DATABASE` and `DROP DATABASE` commands and connection string handling.
Adds supporting tests.

Fixes https://github.com/bubibubi/EntityFrameworkCore.Jet/issues/83#issuecomment-737865826