### PR TITLE
When creating databases, automatically use the latest database version that is supported by the current file extension

### DIFF
--- a/src/EFCore.Jet.Data/AdoxDatabaseCreator.cs
+++ b/src/EFCore.Jet.Data/AdoxDatabaseCreator.cs
@@ -8,7 +8,7 @@ namespace EntityFrameworkCore.Jet.Data
     {
         public override void CreateDatabase(
             string fileNameOrConnectionString,
-            DatabaseVersion version = DatabaseVersion.Newest,
+            DatabaseVersion version = DatabaseVersion.NewestSupported,
             CollatingOrder collatingOrder = CollatingOrder.General,
             string databasePassword = null)
         {
@@ -20,10 +20,16 @@ namespace EntityFrameworkCore.Jet.Data
             
             var filePath = JetStoreDatabaseHandling.ExpandFileName(JetStoreDatabaseHandling.ExtractFileNameFromConnectionString(fileNameOrConnectionString));
             
+            if (version == DatabaseVersion.NewestSupported &&
+                string.Equals(System.IO.Path.GetExtension(filePath), ".mdb"))
+            {
+                version = DatabaseVersion.Version40;
+            }
+
             try
             {
                 using dynamic catalog = new ComObject("ADOX.Catalog");
-
+                
                 // ADOX is an ADO eXtension and ADO is build on top of OLE DB.
                 var connectionString = GetConnectionString(filePath, version, collatingOrder, databasePassword);
                 using var connection = catalog.Create(connectionString);
@@ -86,7 +92,6 @@ namespace EntityFrameworkCore.Jet.Data
                 DatabaseVersion.Version30 => 5,
                 DatabaseVersion.Version40 => 5,
                 DatabaseVersion.Version120 => 6,
-                DatabaseVersion.Newest => 0,
                 _ => 0
             };
 

--- a/src/EFCore.Jet.Data/DaoDatabaseCreator.cs
+++ b/src/EFCore.Jet.Data/DaoDatabaseCreator.cs
@@ -9,7 +9,7 @@ namespace EntityFrameworkCore.Jet.Data
     {
         public override void CreateDatabase(
             string fileNameOrConnectionString,
-            DatabaseVersion version = DatabaseVersion.Newest,
+            DatabaseVersion version = DatabaseVersion.NewestSupported,
             CollatingOrder collatingOrder = CollatingOrder.General,
             string databasePassword = null)
         {
@@ -20,6 +20,12 @@ namespace EntityFrameworkCore.Jet.Data
             }
 
             var filePath = JetStoreDatabaseHandling.ExpandFileName(JetStoreDatabaseHandling.ExtractFileNameFromConnectionString(fileNameOrConnectionString));
+            
+            if (version == DatabaseVersion.NewestSupported &&
+                string.Equals(System.IO.Path.GetExtension(filePath), ".mdb"))
+            {
+                version = DatabaseVersion.Version40;
+            }
 
             try
             {
@@ -33,7 +39,6 @@ namespace EntityFrameworkCore.Jet.Data
                     DatabaseVersion.Version30 => (int) DatabaseTypeEnum.dbVersion30,
                     DatabaseVersion.Version40 => (int) DatabaseTypeEnum.dbVersion40,
                     DatabaseVersion.Version120 => (int) DatabaseTypeEnum.dbVersion120,
-                    DatabaseVersion.Newest => 0,
                     _ => 0,
                 };
 

--- a/src/EFCore.Jet.Data/IJetDatabaseCreator.cs
+++ b/src/EFCore.Jet.Data/IJetDatabaseCreator.cs
@@ -31,7 +31,8 @@ namespace EntityFrameworkCore.Jet.Data
 
     public enum DatabaseVersion
     {
-        Newest = 0,
+        Newest = -1,
+        NewestSupported = 0,
         Version10 = 10,
         Version11 = 11,
         Version20 = 20,
@@ -44,7 +45,7 @@ namespace EntityFrameworkCore.Jet.Data
     {
         void CreateDatabase(
             string fileNameOrConnectionString,
-            DatabaseVersion version = DatabaseVersion.Newest,
+            DatabaseVersion version = DatabaseVersion.NewestSupported,
             CollatingOrder collatingOrder = CollatingOrder.General,
             string databasePassword = null);
 

--- a/src/EFCore.Jet.Data/JetConnection.cs
+++ b/src/EFCore.Jet.Data/JetConnection.cs
@@ -506,14 +506,14 @@ namespace EntityFrameworkCore.Jet.Data
             => InnerConnectionFactory.Instance.ClearAllPools();
 
         public void CreateDatabase(
-            DatabaseVersion version = DatabaseVersion.Newest,
+            DatabaseVersion version = DatabaseVersion.NewestSupported,
             CollatingOrder collatingOrder = CollatingOrder.General,
             string databasePassword = null)
             => CreateDatabase(DataSource, version, collatingOrder, databasePassword, SchemaProviderType);
 
         public static void CreateDatabase(
             string fileNameOrConnectionString,
-            DatabaseVersion version = DatabaseVersion.Newest,
+            DatabaseVersion version = DatabaseVersion.NewestSupported,
             CollatingOrder collatingOrder = CollatingOrder.General,
             string databasePassword = null,
             SchemaProviderType schemaProviderType = SchemaProviderType.Precise)

--- a/src/EFCore.Jet.Data/JetDatabaseCreator.cs
+++ b/src/EFCore.Jet.Data/JetDatabaseCreator.cs
@@ -13,7 +13,7 @@ namespace EntityFrameworkCore.Jet.Data
                 _ => throw new ArgumentOutOfRangeException(nameof(schemaProviderType))
             };
 
-        public abstract void CreateDatabase(string fileNameOrConnectionString, DatabaseVersion version = DatabaseVersion.Newest, CollatingOrder collatingOrder = CollatingOrder.General, string databasePassword = null);
+        public abstract void CreateDatabase(string fileNameOrConnectionString, DatabaseVersion version = DatabaseVersion.NewestSupported, CollatingOrder collatingOrder = CollatingOrder.General, string databasePassword = null);
         public abstract void CreateDualTable(string fileNameOrConnectionString, string databasePassword = null);
     }
 }

--- a/src/EFCore.Jet.Data/PreciseDatabaseCreator.cs
+++ b/src/EFCore.Jet.Data/PreciseDatabaseCreator.cs
@@ -5,7 +5,7 @@ namespace EntityFrameworkCore.Jet.Data
     {
         public override void CreateDatabase(
             string fileNameOrConnectionString,
-            DatabaseVersion version = DatabaseVersion.Newest,
+            DatabaseVersion version = DatabaseVersion.NewestSupported,
             CollatingOrder collatingOrder = CollatingOrder.General,
             string databasePassword = null)
             => new DaoDatabaseCreator().CreateDatabase(fileNameOrConnectionString, version, collatingOrder, databasePassword);

--- a/test/EFCore.Jet.Data.Tests/Helpers.cs
+++ b/test/EFCore.Jet.Data.Tests/Helpers.cs
@@ -261,7 +261,7 @@ namespace EntityFrameworkCore.Jet.Data.Tests
 
         public static void CreateDatabase(
             string storeName,
-            DatabaseVersion version = DatabaseVersion.Newest,
+            DatabaseVersion version = DatabaseVersion.NewestSupported,
             CollatingOrder collatingOrder = CollatingOrder.General,
             string databasePassword = null)
         {


### PR DESCRIPTION
Fixes the `System.Data.OleDb.OleDbException (0x80004005): Unrecognized database format 'test.mdb'.` issue described in https://github.com/bubibubi/EntityFrameworkCore.Jet/issues/83#issuecomment-741827574 when using the `Microsoft.Jet.OLEDB.4.0` provider.