### PR TITLE
Add support for PASSWORD clause in EFCore.Jet specific CREATE DATABASE statement

### DIFF
--- a/src/EFCore.Jet/Migrations/JetMigrationsSqlGenerator.cs
+++ b/src/EFCore.Jet/Migrations/JetMigrationsSqlGenerator.cs
@@ -449,6 +449,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append("CREATE DATABASE ")
                 .Append(_keepBreakingCharactersStringTypeMapping.GenerateSqlLiteral(operation.Name));
 
+            if (!string.IsNullOrEmpty(operation.Password))
+            {
+                builder
+                    .Append(" PASSWORD ")
+                    .Append(_keepBreakingCharactersStringTypeMapping.GenerateSqlLiteral(operation.Password));
+            }
+
             builder
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
                 .EndCommand(suppressTransaction: true);

--- a/src/EFCore.Jet/Migrations/Operations/JetCreateDatabaseOperation.cs
+++ b/src/EFCore.Jet/Migrations/Operations/JetCreateDatabaseOperation.cs
@@ -14,5 +14,6 @@ namespace EntityFrameworkCore.Jet.Migrations.Operations
         ///     The name of the database.
         /// </summary>
         public virtual string Name { get; [param: NotNull] set; }
+        public virtual string Password { get; [param: CanBeNull] set; }
     }
 }

--- a/src/EFCore.Jet/Storage/Internal/JetDatabaseCreator.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDatabaseCreator.cs
@@ -103,15 +103,25 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
 
         private IReadOnlyList<MigrationCommand> CreateCreateOperations()
         {
-            var dataSource = _relationalConnection.DbConnection.DataSource;
-
             // Alternative:
-            // var connection = (JetConnection) _relationalConnection.DbConnection;
-            // var csb = connection.JetFactory.CreateConnectionStringBuilder();
-            // csb.ConnectionString = connection.ConnectionString;
-            // var dataSource = csb.GetDataSource();
+            // var dataSource = _relationalConnection.DbConnection.DataSource;
+
+            var connection = (JetConnection) _relationalConnection.DbConnection;
+            var csb = connection.JetFactory.CreateConnectionStringBuilder();
+            csb.ConnectionString = connection.ConnectionString;
             
-            return Dependencies.MigrationsSqlGenerator.Generate(new[] {new JetCreateDatabaseOperation {Name = dataSource}});
+            var dataSource = csb.GetDataSource();
+            var databasePassword = csb.GetDatabasePassword();
+
+            return Dependencies.MigrationsSqlGenerator.Generate(
+                new[]
+                {
+                    new JetCreateDatabaseOperation
+                    {
+                        Name = dataSource,
+                        Password = databasePassword
+                    }
+                });
         }
 
         /// <summary>

--- a/test/EFCore.Jet.Data.Tests/CreateDatabaseTest.cs
+++ b/test/EFCore.Jet.Data.Tests/CreateDatabaseTest.cs
@@ -89,5 +89,25 @@ namespace EntityFrameworkCore.Jet.Data.Tests
             connection.DropDatabase();
             Assert.IsFalse(File.Exists(StoreName));
         }
+        
+        [TestMethod]
+        public void CreateDatabaseWithPassword()
+        {
+            var password = "Joe's password";
+            var escapedPassword = password.Replace("'", "''");
+            using var connection = new JetConnection(Helpers.DataAccessProviderFactory);
+            
+            var command = connection.CreateCommand();
+            command.CommandText = $"CREATE DATABASE '{StoreName}' PASSWORD '{escapedPassword}'";
+            command.ExecuteNonQuery();
+            Assert.IsTrue(File.Exists(StoreName));
+
+            var csb = Helpers.DataAccessProviderFactory.CreateConnectionStringBuilder();
+            csb.SetDataSource(StoreName);
+            csb.SetDatabasePassword(password);
+            
+            connection.ConnectionString = csb.ConnectionString;
+            connection.Open();
+        }
     }
 }


### PR DESCRIPTION
> If I change the provider to `Microsoft.ACE.OLEDB.12.0` this works but the migration does not create an database password.

> Your sample code uses the `Database.EnsureCreated()` method, which generates a EFCore.Jet specific `CREATE DATABASE` statement. This statement currently does not support specifying a password [...]

This adds database password support to the `CREATE DATABASE` statement.

When EF Core migrations run and a database password is specified in a connection string, the provided password will be translated into the `CREATE DATABASE` statement.
(We might want to think about, whether we only want to enable that, if the `Persist Security Info=False` connection string option has been specified.)