### PR TITLE
Fix create database operations and multi statement splitting with parameters

### DIFF
--- a/src/EFCore.Jet.Data/JetCommandParser.cs
+++ b/src/EFCore.Jet.Data/JetCommandParser.cs
@@ -18,37 +18,7 @@ namespace EntityFrameworkCore.Jet.Data
         }
 
         public IReadOnlyList<int> GetStateIndices(char state, int start = 0, int length = -1)
-        {
-            if (start < 0 ||
-                start >= States.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(start));
-            }
-
-            if (length < 0 ||
-                length > 0 && start + length > States.Length)
-            {
-                length = States.Length - start;
-            }
-
-            var stateIndices = new List<int>();
-            char? lastState = null;
-
-            for (var i = start; i < length; i++)
-            {
-                var currentState = States[i];
-
-                if (currentState == state &&
-                    currentState != lastState)
-                {
-                    stateIndices.Add(i);
-                }
-
-                lastState = currentState;
-            }
-
-            return stateIndices.AsReadOnly();
-        }
+            => GetStateIndices(new[] {state}, start, length);
 
         public IReadOnlyList<int> GetStateIndices(char[] states, int start = 0, int length = -1)
         {
@@ -77,7 +47,7 @@ namespace EntityFrameworkCore.Jet.Data
             var stateIndices = new List<int>();
             char? lastState = null;
 
-            for (var i = start; i < length; i++)
+            for (var i = start; i < start + length; i++)
             {
                 var currentState = States[i];
 

--- a/src/EFCore.Jet/Storage/Internal/JetDatabaseCreator.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDatabaseCreator.cs
@@ -107,8 +107,11 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
             // var dataSource = _relationalConnection.DbConnection.DataSource;
 
             var connection = (JetConnection) _relationalConnection.DbConnection;
+            var fileNameOrConnectionString = connection.ConnectionString;
+            var connectionString = JetConnection.GetConnectionString(fileNameOrConnectionString, connection.DataAccessProviderFactory);
+
             var csb = connection.JetFactory.CreateConnectionStringBuilder();
-            csb.ConnectionString = connection.ConnectionString;
+            csb.ConnectionString = connectionString;
             
             var dataSource = csb.GetDataSource();
             var databasePassword = csb.GetDatabasePassword();


### PR DESCRIPTION
* Fix file create database operations when using file name only connection strings (e.g. `MyDatabase.accdb`).
* Fix automatically assigned file extensions when creating databases.
* Fix parser to correctly return state indices of sub commands. This is a fix for commands containing more than one actual SQL statement in its command text, when those multiple actual SQL statements are using parameters. An example are `INSERT` commands, that are followed by a `SELECT` statement immediately afterwards in the same command. Those `SELECT` statements usually reference the same parameter used for the primary key (if explicitly specified).