### PR TITLE
Return default value for JetDateTimeTypeMapping derived classes as well

### DIFF
--- a/src/EFCore.Jet/Storage/Internal/JetDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDateTimeOffsetTypeMapping.cs
@@ -45,10 +45,7 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
             base.ConfigureParameter(parameter);
         }
 
-        protected override string GenerateNonNullSqlLiteral(object value)
-            => base.GenerateNonNullSqlLiteral(
-                value is DateTimeOffset dateTimeOffset
-                    ? dateTimeOffset.UtcDateTime
-                    : value);
+        protected override DateTime ConvertToDateTimeCompatibleValue(object value)
+            => ((DateTimeOffset) value).UtcDateTime;
     }
 }

--- a/src/EFCore.Jet/Storage/Internal/JetDateTimeTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDateTimeTypeMapping.cs
@@ -53,17 +53,17 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
         }
 
         protected override string GenerateNonNullSqlLiteral(object value)
-            => GenerateNonNullSqlLiteral(value, false, _options.EnableMillisecondsSupport);
+            => GenerateNonNullSqlLiteral(value, false);
 
-        public static string GenerateNonNullSqlLiteral(object value, bool defaultClauseCompatible, bool millisecondsSupportEnabled)
+        public virtual string GenerateNonNullSqlLiteral(object value, bool defaultClauseCompatible)
         {
-            var dateTime = (DateTime) value;
+            var dateTime = ConvertToDateTimeCompatibleValue(value);
 
             dateTime = CheckDateTimeValue(dateTime);
 
             if (defaultClauseCompatible)
             {
-                return _decimalTypeMapping.GenerateSqlLiteral(GetDateTimeDoubleValueAsDecimal(dateTime, millisecondsSupportEnabled));
+                return _decimalTypeMapping.GenerateSqlLiteral(GetDateTimeDoubleValueAsDecimal(dateTime, _options.EnableMillisecondsSupport));
             }
             
             var literal = new StringBuilder()
@@ -77,7 +77,7 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
 
             literal.Append("#");
                 
-            if (millisecondsSupportEnabled &&
+            if (_options.EnableMillisecondsSupport &&
                 time != TimeSpan.Zero)
             {
                 // Round to milliseconds.
@@ -96,6 +96,9 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
 
             return literal.ToString();
         }
+
+        protected virtual DateTime ConvertToDateTimeCompatibleValue(object value)
+            => (DateTime) value;
 
         private static decimal GetDateTimeDoubleValueAsDecimal(DateTime dateTime, bool millisecondsSupportEnabled)
         {

--- a/src/EFCore.Jet/Storage/Internal/JetTimeSpanTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetTimeSpanTypeMapping.cs
@@ -28,7 +28,7 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new JetTimeSpanTypeMapping(parameters, _options);
         
-        protected override string GenerateNonNullSqlLiteral(object value)
-            => base.GenerateNonNullSqlLiteral(JetConfiguration.TimeSpanOffset + (TimeSpan) value);
+        protected override DateTime ConvertToDateTimeCompatibleValue(object value)
+            => JetConfiguration.TimeSpanOffset + (TimeSpan) value;
     }
 }


### PR DESCRIPTION
Before this PR, we would unexpectedly throw an exception, when generating a DEFAULT value clause for a non-`DateTime` CLR type (namely `DateTimeOffset` and `TimeSpan`).