### PR TITLE
Ensure columns of relationships (FK -> PK/AK) are applied in the original order, when scaffolding

### DIFF
--- a/src/EFCore.Jet.Data/AdoxSchema.cs
+++ b/src/EFCore.Jet.Data/AdoxSchema.cs
@@ -471,7 +471,8 @@ namespace EntityFrameworkCore.Jet.Data
                             dataTable.Rows.Add(
                                 relationName,
                                 referencingColumnName,
-                                principalColumnName);
+                                principalColumnName,
+                                k + 1);
                         }
                     }
                 }

--- a/src/EFCore.Jet.Data/DaoSchema.cs
+++ b/src/EFCore.Jet.Data/DaoSchema.cs
@@ -470,7 +470,8 @@ namespace EntityFrameworkCore.Jet.Data
                     dataTable.Rows.Add(
                         relationName,
                         referencingColumnName,
-                        principalColumnName);
+                        principalColumnName,
+                        j + 1);
                 }
             }
 

--- a/src/EFCore.Jet.Data/JetStoreSchemaDefinition/SchemaTables.cs
+++ b/src/EFCore.Jet.Data/JetStoreSchemaDefinition/SchemaTables.cs
@@ -110,6 +110,7 @@ namespace EntityFrameworkCore.Jet.Data.JetStoreSchemaDefinition
                     new DataColumn("RELATION_NAME", typeof(string)),
                     new DataColumn("REFERENCING_COLUMN_NAME", typeof(string)),
                     new DataColumn("PRINCIPAL_COLUMN_NAME", typeof(string)),
+                    new DataColumn("ORDINAL_POSITION", typeof(int)),
                 });
             
             return dataTable;

--- a/src/EFCore.Jet/Scaffolding/Internal/JetDatabaseModelFactory.cs
+++ b/src/EFCore.Jet/Scaffolding/Internal/JetDatabaseModelFactory.cs
@@ -443,7 +443,7 @@ namespace EntityFrameworkCore.Jet.Scaffolding.Internal
             var relationColumnsTable = new DataTable();
             using (var command = connection.CreateCommand())
             {
-                command.CommandText = "SELECT * FROM `INFORMATION_SCHEMA.RELATION_COLUMNS` ORDER BY RELATION_NAME, REFERENCING_COLUMN_NAME, PRINCIPAL_COLUMN_NAME";
+                command.CommandText = "SELECT * FROM `INFORMATION_SCHEMA.RELATION_COLUMNS` ORDER BY RELATION_NAME, ORDINAL_POSITION"; // no sorting would be fine as well
                 using var reader = command.ExecuteReader();
                 relationColumnsTable.Load(reader);
             }

--- a/test/EFCore.Jet.Data.Tests/JetInformationSchemaTest.cs
+++ b/test/EFCore.Jet.Data.Tests/JetInformationSchemaTest.cs
@@ -229,9 +229,9 @@ WHERE RELATION_NAME = 'FK_Order_Details_Orders'
 ORDER BY RELATION_NAME, REFERENCING_COLUMN_NAME, PRINCIPAL_COLUMN_NAME");
             
             AssertDataReaderContent(result, @"
-`RELATION_NAME` | `REFERENCING_COLUMN_NAME` | `PRINCIPAL_COLUMN_NAME`
---- | --- | ---
-FK_Order_Details_Orders | OrderID | OrderID");
+`RELATION_NAME` | `REFERENCING_COLUMN_NAME` | `PRINCIPAL_COLUMN_NAME` | `ORDINAL_POSITION`
+--- | --- | --- | ---
+FK_Order_Details_Orders | OrderID | OrderID | 1");
         }
 
         [DataTestMethod]

--- a/test/EFCore.Jet.FunctionalTests/Scaffolding/JetDatabaseModelFactoryTest.cs
+++ b/test/EFCore.Jet.FunctionalTests/Scaffolding/JetDatabaseModelFactoryTest.cs
@@ -1511,6 +1511,36 @@ DROP TABLE DependentTable;
 DROP TABLE PrincipalTable;");
         }
 
+        [ConditionalFact]
+        public void Relationship_column_order_is_as_defined()
+        {
+            Test(
+                @"
+CREATE TABLE PrincipalTable (
+    IdB int,
+    IdA int,
+    PRIMARY KEY (IdB, IdA)
+);
+
+CREATE TABLE DependentTable (
+    Id int PRIMARY KEY,
+    ForeignKeyIdB int,
+    ForeignKeyIdA int,
+    FOREIGN KEY (ForeignKeyIdB, ForeignKeyIdA) REFERENCES PrincipalTable(IdB, IdA)
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var fk = Assert.Single(dbModel.Tables.Single(t => t.Name == "DependentTable").ForeignKeys);
+                    
+                    Assert.Equal(fk.PrincipalColumns, fk.PrincipalTable.PrimaryKey.Columns);
+                },
+                @"
+DROP TABLE DependentTable;
+DROP TABLE PrincipalTable;");
+        }
+
         #endregion
 
         #region Warnings


### PR DESCRIPTION
Fixes #103 