### PR TITLE
Add missing `counter` usage cases

### DIFF
--- a/src/EFCore.Jet/Migrations/JetMigrationsSqlGenerator.cs
+++ b/src/EFCore.Jet/Migrations/JetMigrationsSqlGenerator.cs
@@ -735,14 +735,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         {
             var storeType = operation.ColumnType;
             
-            if (IsIdentity(operation))
+            if (IsIdentity(operation) &&
+                (storeType == null || Dependencies.TypeMappingSource.FindMapping(storeType) is JetIntTypeMapping))
             {
                 // This column represents the actual identity.
-                if (storeType != null &&
-                    Dependencies.TypeMappingSource.FindMapping(storeType) is JetIntTypeMapping)
-                {
-                    storeType = "counter";
-                }
+                storeType = "counter";
             }
             else if (storeType != null &&
                      IsExplicitIdentityColumnType(storeType))

--- a/test/EFCore.Jet.Tests/JetMigrationTest.cs
+++ b/test/EFCore.Jet.Tests/JetMigrationTest.cs
@@ -36,7 +36,7 @@ namespace EntityFrameworkCore.Jet
             
             AssertSql(
                 $@"CREATE TABLE `Cookie` (
-    `CookieId` integer NOT NULL,
+    `CookieId` counter NOT NULL,
     `Name` longchar NULL,
     `BestServedBefore` datetime NOT NULL DEFAULT #2021-12-31#,
     CONSTRAINT `PK_Cookie` PRIMARY KEY (`CookieId`)


### PR DESCRIPTION
The #112 fix did not cover all scenarios where a `counter` type should be used.

Fixes #110
Fixes #112