### PR TITLE
Disable savepoint API, because it is not supported by Jet

### DIFF
--- a/src/EFCore.Jet/Extensions/JetServiceCollectionExtensions.cs
+++ b/src/EFCore.Jet/Extensions/JetServiceCollectionExtensions.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IQuerySqlGeneratorFactory, JetQuerySqlGeneratorFactory>()
                 .TryAdd<ISqlExpressionFactory, JetSqlExpressionFactory>()
                 .TryAdd<IQueryTranslationPostprocessorFactory, JetQueryTranslationPostprocessorFactory>()
+                .TryAdd<IRelationalTransactionFactory, JetTransactionFactory>()
                 .TryAddProviderSpecificServices(
                     b => b
                         .TryAddSingleton<IJetOptions, JetOptions>()

--- a/src/EFCore.Jet/Storage/Internal/JetTransaction.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetTransaction.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace EntityFrameworkCore.Jet.Storage.Internal
+{
+    public class JetTransaction : RelationalTransaction
+    {
+        /// <inheritdoc />
+        public JetTransaction(
+            [NotNull] IRelationalConnection connection,
+            [NotNull] DbTransaction transaction,
+            Guid transactionId,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger,
+            bool transactionOwned)
+            : base(connection, transaction, transactionId, logger, transactionOwned)
+        {
+        }
+        
+        /// <inheritdoc />
+        public override bool SupportsSavepoints
+            => false;
+
+        /// <inheritdoc />
+        public override void CreateSavepoint(string name)
+            => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override Task CreateSavepointAsync(string name, CancellationToken cancellationToken = new CancellationToken())
+            => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        protected override string GetCreateSavepointSql(string name)
+            => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override void RollbackToSavepoint(string name)
+            => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override Task RollbackToSavepointAsync(string name, CancellationToken cancellationToken = new CancellationToken())
+            => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        protected override string GetRollbackToSavepointSql(string name)
+            => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override void ReleaseSavepoint(string name)
+            => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override Task ReleaseSavepointAsync(string name, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        protected override string GetReleaseSavepointSql(string name)
+            => throw new NotSupportedException();
+    }
+}

--- a/src/EFCore.Jet/Storage/Internal/JetTransactionFactory.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetTransactionFactory.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace EntityFrameworkCore.Jet.Storage.Internal
+{
+    public class JetTransactionFactory : IRelationalTransactionFactory
+    {
+        public virtual RelationalTransaction Create(
+            IRelationalConnection connection,
+            DbTransaction transaction,
+            Guid transactionId,
+            IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger,
+            bool transactionOwned)
+            => new JetTransaction(connection, transaction, transactionId, logger, transactionOwned);
+    }
+}


### PR DESCRIPTION
EF Core 5 introduced usage of the transaction savepoint API, which is not supported by Jet/ACE.

Fixes #125