### PR TITLE
Use double workaround only for DateTime default values if millisecond support has been enabled

### DIFF
--- a/src/EFCore.Jet/Storage/Internal/JetDateTimeTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDateTimeTypeMapping.cs
@@ -61,13 +61,20 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
 
             dateTime = CheckDateTimeValue(dateTime);
 
-            if (defaultClauseCompatible)
+            var literal = new StringBuilder();
+
+            if (defaultClauseCompatible &&
+                _options.EnableMillisecondsSupport)
             {
                 return _decimalTypeMapping.GenerateSqlLiteral(GetDateTimeDoubleValueAsDecimal(dateTime, _options.EnableMillisecondsSupport));
             }
-            
-            var literal = new StringBuilder()
-                .AppendFormat(CultureInfo.InvariantCulture, "#{0:yyyy-MM-dd}", dateTime);
+
+            literal.Append(
+                defaultClauseCompatible
+                    ? "'"
+                    : "#");
+
+            literal.AppendFormat(CultureInfo.InvariantCulture, "{0:yyyy-MM-dd}", dateTime);
                 
             var time = dateTime.TimeOfDay;
             if (time != TimeSpan.Zero)
@@ -75,8 +82,11 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
                 literal.AppendFormat(CultureInfo.InvariantCulture, @" {0:hh\:mm\:ss}", time);
             }
 
-            literal.Append("#");
-                
+            literal.Append(
+                defaultClauseCompatible
+                    ? "'"
+                    : "#");
+
             if (_options.EnableMillisecondsSupport &&
                 time != TimeSpan.Zero)
             {


### PR DESCRIPTION
_From [x86 CI test run](https://bubibubi.visualstudio.com/EntityFrameworkCore.Jet/_build/results?buildId=222&view=logs&j=a763362a-3770-5745-6a16-f3dfcb4f8f90&t=6af94ba7-d474-5824-60a1-b31560662180):_
```
[xUnit.net 00:00:07.68]     EntityFrameworkCore.Jet.JetDateTimeTest.Where_datetime_with_HasDefaultValue [FAIL]
[xUnit.net 00:00:07.69]       Assert.Equal() Failure
[xUnit.net 00:00:07.69]       Expected: 2
[xUnit.net 00:00:07.69]       Actual:   0
[xUnit.net 00:00:07.69]       Stack Trace:
[xUnit.net 00:00:07.69]         D:\a\1\s\test\EFCore.Jet.Tests\JetDateTimeTest.cs(35,0): at EntityFrameworkCore.Jet.JetDateTimeTest.Where_datetime_with_HasDefaultValue()
```