### PR TITLE
Remove unnecessary references in `EntityFrameworkCore.Jet.Data`

### DIFF
--- a/Dependencies.targets
+++ b/Dependencies.targets
@@ -16,11 +16,6 @@
 		<PackageReference Update="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
 		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
-		<!-- EntityFrameworkCore.Jet.Data -->
-		<PackageReference Update="System.ValueTuple" Version="4.5.0" />
-		<PackageReference Update="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Update="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5" />
-
 		<!-- EFCore.Jet -->
 		<PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
 		<PackageReference Update="Microsoft.Extensions.Configuration" Version="6.0.0" />

--- a/src/EFCore.Jet.Data/EFCore.Jet.Data.csproj
+++ b/src/EFCore.Jet.Data/EFCore.Jet.Data.csproj
@@ -9,15 +9,5 @@
         <PackageTags>$(PackageTags);System.Data.Jet</PackageTags>
         <Nullable>annotations</Nullable>
     </PropertyGroup>
-    
-    <ItemGroup>
-        <PackageReference Include="System.ValueTuple" />
-        <PackageReference Include="Microsoft.CSharp" />
-        <PackageReference Include="Microsoft.Win32.Registry" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-        <Reference Include="System.Transactions" Pack="false" />
-    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Now that `EntityFrameworkCore.Jet.Data` targets `net6.0` those references are not required anymore.

Note that the `Microsoft.Win32.Registry` package reference was the root cause of the failure to publish the `EntityFrameworkCore.Jet.Data` 7.0.0 package because of [warning NU5104][1] (treated as error):
> A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "Microsoft.Win32.Registry [6.0.0-preview.5.21301.5, )" or update the version field in the nuspec.

[1]: https://bubibubi.visualstudio.com/EntityFrameworkCore.Jet/_build/results?buildId=280&view=logs&j=67ea8d94-b5a7-504b-2d4b-07baddfad3f1&t=1e07b7f6-b7a1-55f6-9cca-c04683790a41&l=37