### PR TITLE
Revert "Type MApping: a long gets mapped to integer in Jet"

### DIFF
--- a/src/EFCore.Jet/Storage/Internal/JetTypeMappingSource.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetTypeMappingSource.cs
@@ -35,7 +35,7 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
         private readonly JetByteTypeMapping _byte = new JetByteTypeMapping("byte", DbType.Byte); // unsigned, there is no signed byte in Jet
         private readonly ShortTypeMapping _smallint = new ShortTypeMapping("smallint", DbType.Int16);
         private readonly IntTypeMapping _integer = new JetIntTypeMapping("integer");
-        private readonly JetLongTypeMapping _bigint = new JetLongTypeMapping("integer");//a long and integer are the same in Jet
+        private readonly JetLongTypeMapping _bigint = new JetLongTypeMapping("decimal");
 
         private readonly JetFloatTypeMapping _single = new JetFloatTypeMapping("single");
         private readonly JetDoubleTypeMapping _double = new JetDoubleTypeMapping("double");


### PR DESCRIPTION
This reverts commit 05b10ea856c5917c8c87d0870f1109ccff3fc48d.

The `long` datatype in Jet is 32 bit and therefore equals the `Int32` CLR type.
We cannot use it to map the `Int64` CLR type to Jet.

The `decimal` datatype in Jet has a total number of 28 digits, which can be used to represent the largest 64 bit value (signed and unsigned) of `18,446,744,073,709,551,616` (20 digits).

So the original implementation should be correct.