### PR TITLE
Add docker files for testing

### DIFF
--- a/.docker/BuildAllDockerfiles.ps1
+++ b/.docker/BuildAllDockerfiles.ps1
@@ -1,0 +1,1 @@
+﻿Get-ChildItem $PSScriptRoot -Filter '*.dockerfile' -File | ForEach-Object { echo "Build $($_.Name)"; docker build -f $_.FullName -t "$($_.BaseName):latest" (Join-Path $PSScriptRoot '..') }

--- a/.docker/windows-ace-12.0-x64.dockerfile
+++ b/.docker/windows-ace-12.0-x64.dockerfile
@@ -1,0 +1,72 @@
+﻿# asdfescape=`
+
+FROM mcr.microsoft.com/windows:ltsc2019-amd64
+
+ARG ARCHITECTURE=x64
+
+ARG PS_VERSION=7.3.8
+ARG PS_PACKAGE_FILE=PowerShell-$PS_VERSION-win-$ARCHITECTURE.msi
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/$PS_PACKAGE_FILE
+
+ARG ACE_PACKAGE_FILE=AccessDatabaseEngine_x64.exe
+ARG ACE_PACKAGE_URL=https://download.microsoft.com/download/2/4/3/24375141-E08D-4803-AB0E-10F2E3A07AAA/$ACE_PACKAGE_FILE
+ARG ACE_SILENT_INSTALL_ARG=/passive
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    DOTNET_NOLOGO=true
+
+# Ignore any Development.props file by default.
+ENV IgnoreLocalRepositories=true
+
+#
+# Install PowerShell:
+#
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest $env:PS_PACKAGE_URL -OutFile $env:PS_PACKAGE_FILE; \
+    msiexec.exe /package $env:PS_PACKAGE_FILE /quiet ADD_PATH=1 DISABLE_TELEMETRY=1 | Out-Default
+
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN $PSVersionTable; \
+    Set-ExecutionPolicy Unrestricted 
+
+#
+# Install .NET SDK:
+#
+
+COPY global.json dotnet-install-global.json
+
+RUN echo '.NET Information Before SDK Install'; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." } \
+    echo 'Install .NET SDK'; \
+    &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -JSonFile dotnet-install-global.json -Architecture $env:ARCHITECTURE -InstallDir "C:\dotnet_$env:ARCHITECTURE" -Verbose && \
+    [Environment]::SetEnvironmentVariable('Path', $env:Path, 'Machine'); \
+    $env:Path; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." } 
+
+#
+# Install Access Runtime:
+#
+
+RUN Invoke-WebRequest $env:ACE_PACKAGE_URL -OutFile $env:ACE_PACKAGE_FILE && \
+    & ".\$env:ACE_PACKAGE_FILE" $env:ACE_SILENT_INSTALL_ARG | Out-Default && \
+    'DAO:'; \
+    Get-ChildItem 'HKLM:\SOFTWARE\Classes\DAO.DBEngine*' | Select-Object; \
+    'OLE DB:'; \
+    foreach ($provider in [System.Data.OleDb.OleDbEnumerator]::GetRootEnumerator()) { \
+        $v = New-Object PSObject; \
+        for ($i = 0; $i -lt $provider.FieldCount; $i++) { \
+           Add-Member -in $v NoteProperty $provider.GetName($i) $provider.GetValue($i); \
+        } \
+        $v; \
+    } \
+    echo "Architecture: $([Environment]::Is64BitProcess ? 'x64' : 'x86')" 
+
+RUN mkdir 'C:\Source'
+WORKDIR 'C:\Source'
+
+ENTRYPOINT ["pwsh", "-c"]
+CMD ["pwsh"]

--- a/.docker/windows-ace-12.0-x86.dockerfile
+++ b/.docker/windows-ace-12.0-x86.dockerfile
@@ -1,0 +1,72 @@
+﻿# asdfescape=`
+
+FROM mcr.microsoft.com/windows:ltsc2019-amd64
+
+ARG ARCHITECTURE=x86
+
+ARG PS_VERSION=7.3.8
+ARG PS_PACKAGE_FILE=PowerShell-$PS_VERSION-win-$ARCHITECTURE.msi
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/$PS_PACKAGE_FILE
+
+ARG ACE_PACKAGE_FILE=AccessDatabaseEngine.exe
+ARG ACE_PACKAGE_URL=https://download.microsoft.com/download/2/4/3/24375141-E08D-4803-AB0E-10F2E3A07AAA/$ACE_PACKAGE_FILE
+ARG ACE_SILENT_INSTALL_ARG=/passive
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    DOTNET_NOLOGO=true
+
+# Ignore any Development.props file by default.
+ENV IgnoreLocalRepositories=true
+
+#
+# Install PowerShell:
+#
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest $env:PS_PACKAGE_URL -OutFile $env:PS_PACKAGE_FILE; \
+    msiexec.exe /package $env:PS_PACKAGE_FILE /quiet ADD_PATH=1 DISABLE_TELEMETRY=1 | Out-Default
+
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN $PSVersionTable; \
+    Set-ExecutionPolicy Unrestricted 
+
+#
+# Install .NET SDK:
+#
+
+COPY global.json dotnet-install-global.json
+
+RUN echo '.NET Information Before SDK Install'; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." } \
+    echo 'Install .NET SDK'; \
+    &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -JSonFile dotnet-install-global.json -Architecture $env:ARCHITECTURE -InstallDir "C:\dotnet_$env:ARCHITECTURE" -Verbose && \
+    [Environment]::SetEnvironmentVariable('Path', $env:Path, 'Machine'); \
+    $env:Path; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." } 
+
+#
+# Install Access Runtime:
+#
+
+RUN Invoke-WebRequest $env:ACE_PACKAGE_URL -OutFile $env:ACE_PACKAGE_FILE && \
+    & ".\$env:ACE_PACKAGE_FILE" $env:ACE_SILENT_INSTALL_ARG | Out-Default && \
+    'DAO:'; \
+    Get-ChildItem 'HKLM:\SOFTWARE\Classes\DAO.DBEngine*' | Select-Object; \
+    'OLE DB:'; \
+    foreach ($provider in [System.Data.OleDb.OleDbEnumerator]::GetRootEnumerator()) { \
+        $v = New-Object PSObject; \
+        for ($i = 0; $i -lt $provider.FieldCount; $i++) { \
+           Add-Member -in $v NoteProperty $provider.GetName($i) $provider.GetValue($i); \
+        } \
+        $v; \
+    } \
+    echo "Architecture: $([Environment]::Is64BitProcess ? 'x64' : 'x86')" 
+
+RUN mkdir 'C:\Source'
+WORKDIR 'C:\Source'
+
+ENTRYPOINT ["pwsh", "-c"]
+CMD ["pwsh"]

--- a/.docker/windows-ace-16.0-x64.dockerfile
+++ b/.docker/windows-ace-16.0-x64.dockerfile
@@ -1,0 +1,72 @@
+﻿# asdfescape=`
+
+FROM mcr.microsoft.com/windows:ltsc2019-amd64
+
+ARG ARCHITECTURE=x64
+
+ARG PS_VERSION=7.3.8
+ARG PS_PACKAGE_FILE=PowerShell-$PS_VERSION-win-$ARCHITECTURE.msi
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/$PS_PACKAGE_FILE
+
+ARG ACE_PACKAGE_FILE=AccessDatabaseEngine_x64.exe
+ARG ACE_PACKAGE_URL=https://download.microsoft.com/download/3/5/C/35C84C36-661A-44E6-9324-8786B8DBE231/$ACE_PACKAGE_FILE
+ARG ACE_SILENT_INSTALL_ARG=/passive
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    DOTNET_NOLOGO=true
+
+# Ignore any Development.props file by default.
+ENV IgnoreLocalRepositories=true
+
+#
+# Install PowerShell:
+#
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest $env:PS_PACKAGE_URL -OutFile $env:PS_PACKAGE_FILE; \
+    msiexec.exe /package $env:PS_PACKAGE_FILE /quiet ADD_PATH=1 DISABLE_TELEMETRY=1 | Out-Default
+
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN $PSVersionTable; \
+    Set-ExecutionPolicy Unrestricted 
+
+#
+# Install .NET SDK:
+#
+
+COPY global.json dotnet-install-global.json
+
+RUN echo '.NET Information Before SDK Install'; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." } \
+    echo 'Install .NET SDK'; \
+    &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -JSonFile dotnet-install-global.json -Architecture $env:ARCHITECTURE -InstallDir "C:\dotnet_$env:ARCHITECTURE" -Verbose && \
+    [Environment]::SetEnvironmentVariable('Path', $env:Path, 'Machine'); \
+    $env:Path; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." } 
+
+#
+# Install Access Runtime:
+#
+
+RUN Invoke-WebRequest $env:ACE_PACKAGE_URL -OutFile $env:ACE_PACKAGE_FILE && \
+    & ".\$env:ACE_PACKAGE_FILE" $env:ACE_SILENT_INSTALL_ARG | Out-Default && \
+    'DAO:'; \
+    Get-ChildItem 'HKLM:\SOFTWARE\Classes\DAO.DBEngine*' | Select-Object; \
+    'OLE DB:'; \
+    foreach ($provider in [System.Data.OleDb.OleDbEnumerator]::GetRootEnumerator()) { \
+        $v = New-Object PSObject; \
+        for ($i = 0; $i -lt $provider.FieldCount; $i++) { \
+           Add-Member -in $v NoteProperty $provider.GetName($i) $provider.GetValue($i); \
+        } \
+        $v; \
+    } \
+    echo "Architecture: $([Environment]::Is64BitProcess ? 'x64' : 'x86')" 
+
+RUN mkdir 'C:\Source'
+WORKDIR 'C:\Source'
+
+ENTRYPOINT ["pwsh", "-c"]
+CMD ["pwsh"]

--- a/.docker/windows-ace-16.0-x86.dockerfile
+++ b/.docker/windows-ace-16.0-x86.dockerfile
@@ -1,0 +1,72 @@
+﻿# asdfescape=`
+
+FROM mcr.microsoft.com/windows:ltsc2019-amd64
+
+ARG ARCHITECTURE=x86
+
+ARG PS_VERSION=7.3.8
+ARG PS_PACKAGE_FILE=PowerShell-$PS_VERSION-win-$ARCHITECTURE.msi
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/$PS_PACKAGE_FILE
+
+ARG ACE_PACKAGE_FILE=AccessDatabaseEngine.exe
+ARG ACE_PACKAGE_URL=https://download.microsoft.com/download/3/5/C/35C84C36-661A-44E6-9324-8786B8DBE231/$ACE_PACKAGE_FILE
+ARG ACE_SILENT_INSTALL_ARG=/passive
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    DOTNET_NOLOGO=true
+
+# Ignore any Development.props file by default.
+ENV IgnoreLocalRepositories=true
+
+#
+# Install PowerShell:
+#
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest $env:PS_PACKAGE_URL -OutFile $env:PS_PACKAGE_FILE; \
+    msiexec.exe /package $env:PS_PACKAGE_FILE /quiet ADD_PATH=1 DISABLE_TELEMETRY=1 | Out-Default
+
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN $PSVersionTable; \
+    Set-ExecutionPolicy Unrestricted 
+
+#
+# Install .NET SDK:
+#
+
+COPY global.json dotnet-install-global.json
+
+RUN echo '.NET Information Before SDK Install'; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." } \
+    echo 'Install .NET SDK'; \
+    &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -JSonFile dotnet-install-global.json -Architecture $env:ARCHITECTURE -InstallDir "C:\dotnet_$env:ARCHITECTURE" -Verbose && \
+    [Environment]::SetEnvironmentVariable('Path', $env:Path, 'Machine'); \
+    $env:Path; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." } 
+
+#
+# Install Access Runtime:
+#
+
+RUN Invoke-WebRequest $env:ACE_PACKAGE_URL -OutFile $env:ACE_PACKAGE_FILE && \
+    & ".\$env:ACE_PACKAGE_FILE" $env:ACE_SILENT_INSTALL_ARG | Out-Default && \
+    'DAO:'; \
+    Get-ChildItem 'HKLM:\SOFTWARE\Classes\DAO.DBEngine*' | Select-Object; \
+    'OLE DB:'; \
+    foreach ($provider in [System.Data.OleDb.OleDbEnumerator]::GetRootEnumerator()) { \
+        $v = New-Object PSObject; \
+        for ($i = 0; $i -lt $provider.FieldCount; $i++) { \
+           Add-Member -in $v NoteProperty $provider.GetName($i) $provider.GetValue($i); \
+        } \
+        $v; \
+    } \
+    echo "Architecture: $([Environment]::Is64BitProcess ? 'x64' : 'x86')" 
+
+RUN mkdir 'C:\Source'
+WORKDIR 'C:\Source'
+
+ENTRYPOINT ["pwsh", "-c"]
+CMD ["pwsh"]

--- a/.docker/windows-ace-none-x64.dockerfile
+++ b/.docker/windows-ace-none-x64.dockerfile
@@ -1,0 +1,66 @@
+﻿# asdfescape=`
+
+FROM mcr.microsoft.com/windows:ltsc2019-amd64
+
+ARG ARCHITECTURE=x64
+
+ARG PS_VERSION=7.3.8
+ARG PS_PACKAGE_FILE=PowerShell-$PS_VERSION-win-$ARCHITECTURE.msi
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/$PS_PACKAGE_FILE
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    DOTNET_NOLOGO=true
+
+# Ignore any Development.props file by default.
+ENV IgnoreLocalRepositories=true
+
+#
+# Install PowerShell:
+#
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest $env:PS_PACKAGE_URL -OutFile $env:PS_PACKAGE_FILE; \
+    msiexec.exe /package $env:PS_PACKAGE_FILE /quiet ADD_PATH=1 DISABLE_TELEMETRY=1 | Out-Default
+
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN $PSVersionTable; \
+    Set-ExecutionPolicy Unrestricted 
+
+#
+# Install .NET SDK:
+#
+
+COPY global.json dotnet-install-global.json
+
+RUN echo '.NET Information Before SDK Install'; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." } \
+    echo 'Install .NET SDK'; \
+    &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -JSonFile dotnet-install-global.json -Architecture $env:ARCHITECTURE -InstallDir "C:\dotnet_$env:ARCHITECTURE" -Verbose && \
+    [Environment]::SetEnvironmentVariable('Path', $env:Path, 'Machine'); \
+    $env:Path; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." }
+
+#
+# Output provider information:
+#
+
+RUN 'DAO:'; \
+    Get-ChildItem 'HKLM:\SOFTWARE\Classes\DAO.DBEngine*' | Select-Object; \
+    'OLE DB:'; \
+    foreach ($provider in [System.Data.OleDb.OleDbEnumerator]::GetRootEnumerator()) { \
+        $v = New-Object PSObject; \
+        for ($i = 0; $i -lt $provider.FieldCount; $i++) { \
+           Add-Member -in $v NoteProperty $provider.GetName($i) $provider.GetValue($i); \
+        } \
+        $v; \
+    } \
+    echo "Architecture: $([Environment]::Is64BitProcess ? 'x64' : 'x86')" 
+
+RUN mkdir 'C:\Source'
+WORKDIR 'C:\Source'
+
+ENTRYPOINT ["pwsh", "-c"]
+CMD ["pwsh"]

--- a/.docker/windows-ace-none-x86.dockerfile
+++ b/.docker/windows-ace-none-x86.dockerfile
@@ -1,0 +1,66 @@
+﻿# asdfescape=`
+
+FROM mcr.microsoft.com/windows:ltsc2019-amd64
+
+ARG ARCHITECTURE=x86
+
+ARG PS_VERSION=7.3.8
+ARG PS_PACKAGE_FILE=PowerShell-$PS_VERSION-win-$ARCHITECTURE.msi
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/$PS_PACKAGE_FILE
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    DOTNET_NOLOGO=true
+
+# Ignore any Development.props file by default.
+ENV IgnoreLocalRepositories=true
+
+#
+# Install PowerShell:
+#
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest $env:PS_PACKAGE_URL -OutFile $env:PS_PACKAGE_FILE; \
+    msiexec.exe /package $env:PS_PACKAGE_FILE /quiet ADD_PATH=1 DISABLE_TELEMETRY=1 | Out-Default
+
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN $PSVersionTable; \
+    Set-ExecutionPolicy Unrestricted 
+
+#
+# Install .NET SDK:
+#
+
+COPY global.json dotnet-install-global.json
+
+RUN echo '.NET Information Before SDK Install'; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." } \
+    echo 'Install .NET SDK'; \
+    &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -JSonFile dotnet-install-global.json -Architecture $env:ARCHITECTURE -InstallDir "C:\dotnet_$env:ARCHITECTURE" -Verbose && \
+    [Environment]::SetEnvironmentVariable('Path', $env:Path, 'Machine'); \
+    $env:Path; \
+    try { dotnet --info } catch { echo "No $env:ARCHITECTURE .NET SDK installed." }
+
+#
+# Output provider information:
+#
+
+RUN 'DAO:'; \
+    Get-ChildItem 'HKLM:\SOFTWARE\Classes\DAO.DBEngine*' | Select-Object; \
+    'OLE DB:'; \
+    foreach ($provider in [System.Data.OleDb.OleDbEnumerator]::GetRootEnumerator()) { \
+        $v = New-Object PSObject; \
+        for ($i = 0; $i -lt $provider.FieldCount; $i++) { \
+           Add-Member -in $v NoteProperty $provider.GetName($i) $provider.GetValue($i); \
+        } \
+        $v; \
+    } \
+    echo "Architecture: $([Environment]::Is64BitProcess ? 'x64' : 'x86')" 
+
+RUN mkdir 'C:\Source'
+WORKDIR 'C:\Source'
+
+ENTRYPOINT ["pwsh", "-c"]
+CMD ["pwsh"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+﻿**
+!global.json

--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ $RECYCLE.BIN/
 /msbuild/Compile
 /msbuild/Output
 /.vs/EntityFrameworkCore.Jet
-/.dotnet*/
+/.dotnet*
+/.run-local
 .idea
 Development.props

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="Version.props" />
-  <Import Project="Development.props" Condition="Exists('Development.props')" />
+  <Import Project="Development.props" Condition="Exists('Development.props') And '$(IgnoreLocalRepositories)' != 'true'" />
 
   <PropertyGroup>
     <Product>EntityFrameworkCore.Jet</Product>


### PR DESCRIPTION
Adds docker files and a build script to build windows based docker images that contain the different test environments we also use in CI.
They can be leveraged to locally run tests, without having to install multiple ACE versions in parallel on the development machine.

To build the images, run:

```powershell
.\.docker\BuildAllDockerfiles.ps1
```

To run tests, use a command similar to the following:
```powershell
docker run --rm --name 'ace-test' -v 'C:\Repositories\EFCore.Jet:C:\Source' -e 'EFCoreJet_DefaultConnection=Data Source=Jet.accdb' 'windows-ace-12.0-x86:latest' 'dotnet test -v:m -p:FixedTestOrder=true .\test\EFCore.Jet.FunctionalTests\EFCore.Jet.FunctionalTests.csproj --logger "trx;LogFileName=TestResult.xml" --results-directory .\TestResults --logger "console;verbosity=minimal" --blame-hang-timeout 3m'
```