### PR TITLE
Fix automatic test skipping

### DIFF
--- a/src/EFCore.Jet/Utilities/ExceptionExtensions.cs
+++ b/src/EFCore.Jet/Utilities/ExceptionExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace System;
+
+public static class ExceptionExtensions
+{
+    public static IEnumerable<Exception> FlattenHierarchy(this Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        var innerException = ex;
+        do
+        {
+            yield return innerException;
+            innerException = innerException.InnerException;
+        }
+        while (innerException != null);
+    }
+}


### PR DESCRIPTION
This corrects the skipping logic for now.
More good stuff and some cleanup will be pushed as part of the crash handling code in a later PR.

Fixes https://github.com/bubibubi/EntityFrameworkCore.Jet/pull/152#issuecomment-1764365190