### PR TITLE
Fix using decimal and Int64 in parameters

### DIFF
--- a/src/EFCore.Jet/EFCore.Jet.csproj
+++ b/src/EFCore.Jet/EFCore.Jet.csproj
@@ -45,6 +45,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="System.Data.Odbc" />
+		<PackageReference Include="System.Data.OleDb" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\EFCore.Jet.Data\EFCore.Jet.Data.csproj" />
 	</ItemGroup>
 

--- a/src/EFCore.Jet/Storage/Internal/JetDecimalTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetDecimalTypeMapping.cs
@@ -1,5 +1,7 @@
 using System.Data;
 using System.Data.Common;
+using System.Data.Odbc;
+using System.Data.OleDb;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -77,7 +79,18 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
         protected override void ConfigureParameter(DbParameter parameter)
         {
             base.ConfigureParameter(parameter);
-
+            //Decimals needs to be mapped to Numeric for Jet.
+            //Using Decimal is fine for OleDb but Odbc doesn't like it.
+            //Have to use Numeric for Odbc.
+            //Suspect this will also fix any formatting erros with , and . for decimal separator and space and , for digit separator
+            if (parameter is OdbcParameter odbcParameter)
+            {
+                odbcParameter.OdbcType = OdbcType.Numeric;
+            }
+            else if (parameter is OleDbParameter oleDbParameter)
+            {
+                oleDbParameter.OleDbType = OleDbType.Numeric;
+            }
             if (Size.HasValue
                 && Size.Value != -1)
             {

--- a/src/EFCore.Jet/Storage/Internal/JetLongTypeMapping.cs
+++ b/src/EFCore.Jet/Storage/Internal/JetLongTypeMapping.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
+using System.Data.Common;
 
 namespace EntityFrameworkCore.Jet.Storage.Internal
 {
@@ -9,7 +10,7 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
             : base(storeType, System.Data.DbType.Int64)
         {
         }
-        
+
         protected JetLongTypeMapping(RelationalTypeMappingParameters parameters)
             : base(parameters)
         {
@@ -17,5 +18,14 @@ namespace EntityFrameworkCore.Jet.Storage.Internal
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new JetLongTypeMapping(parameters);
+
+        protected override void ConfigureParameter(DbParameter parameter)
+        {
+            base.ConfigureParameter(parameter);
+            //Needs to be Object. Using BigInt doesn't always work
+            //If the argument value is a long and within Int32 range, having it as BigInt in x86 works
+            //When running in x64 it fails to convert. Using Object bypasses the conversion
+            parameter.DbType = System.Data.DbType.Object;
+        }
     }
 }

--- a/test/EFCore.Jet.FunctionalTests/Query/NorthwindWhereQueryJetTest.cs
+++ b/test/EFCore.Jet.FunctionalTests/Query/NorthwindWhereQueryJetTest.cs
@@ -165,20 +165,20 @@ WHERE `c`.`City` = @__city_0
 
             AssertSql(
                 """
-    @__p_0='2' (Nullable = true)
-    
-    SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
-    FROM `Employees` AS `e`
-    WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
-    """,
+@__p_0='2' (Nullable = true) (DbType = Object)
+
+SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
+FROM `Employees` AS `e`
+WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
+""",
                 //
                 """
-    @__p_0='5' (Nullable = true)
-    
-    SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
-    FROM `Employees` AS `e`
-    WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
-    """);
+@__p_0='5' (Nullable = true) (DbType = Object)
+
+SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
+FROM `Employees` AS `e`
+WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
+""");
         }
 
         public override async Task Where_method_call_nullable_type_reverse_closure_via_query_cache(bool isAsync)
@@ -187,20 +187,20 @@ WHERE `c`.`City` = @__city_0
 
             AssertSql(
                 """
-    @__p_0='1' (Nullable = true)
-    
-    SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
-    FROM `Employees` AS `e`
-    WHERE CLNG(`e`.`EmployeeID`) > @__p_0
-    """,
+@__p_0='1' (Nullable = true) (DbType = Object)
+
+SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
+FROM `Employees` AS `e`
+WHERE CLNG(`e`.`EmployeeID`) > @__p_0
+""",
                 //
                 """
-    @__p_0='5' (Nullable = true)
-    
-    SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
-    FROM `Employees` AS `e`
-    WHERE CLNG(`e`.`EmployeeID`) > @__p_0
-    """);
+@__p_0='5' (Nullable = true) (DbType = Object)
+
+SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
+FROM `Employees` AS `e`
+WHERE CLNG(`e`.`EmployeeID`) > @__p_0
+""");
         }
 
         public override async Task Where_method_call_closure_via_query_cache(bool isAsync)
@@ -407,26 +407,26 @@ WHERE `c`.`City` = @__InstanceFieldValue_0
 
             AssertSql(
                 """
-    @__p_0='2' (Nullable = true)
-    
-    SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
-    FROM `Employees` AS `e`
-    WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
-    """,
+@__p_0='2' (Nullable = true) (DbType = Object)
+
+SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
+FROM `Employees` AS `e`
+WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
+""",
                 //
                 """
-    @__p_0='5' (Nullable = true)
-    
-    SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
-    FROM `Employees` AS `e`
-    WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
-    """,
+@__p_0='5' (Nullable = true) (DbType = Object)
+
+SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
+FROM `Employees` AS `e`
+WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
+""",
                 //
                 """
-    SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
-    FROM `Employees` AS `e`
-    WHERE `e`.`ReportsTo` IS NULL
-    """);
+SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
+FROM `Employees` AS `e`
+WHERE `e`.`ReportsTo` IS NULL
+""");
         }
 
         public override async Task Where_simple_closure_via_query_cache_nullable_type_reverse(bool isAsync)
@@ -435,26 +435,26 @@ WHERE `c`.`City` = @__InstanceFieldValue_0
 
             AssertSql(
                 """
-    SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
-    FROM `Employees` AS `e`
-    WHERE `e`.`ReportsTo` IS NULL
-    """,
+SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
+FROM `Employees` AS `e`
+WHERE `e`.`ReportsTo` IS NULL
+""",
                 //
                 """
-    @__p_0='5' (Nullable = true)
-    
-    SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
-    FROM `Employees` AS `e`
-    WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
-    """,
+@__p_0='5' (Nullable = true) (DbType = Object)
+
+SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
+FROM `Employees` AS `e`
+WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
+""",
                 //
                 """
-    @__p_0='2' (Nullable = true)
-    
-    SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
-    FROM `Employees` AS `e`
-    WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
-    """);
+@__p_0='2' (Nullable = true) (DbType = Object)
+
+SELECT `e`.`EmployeeID`, `e`.`City`, `e`.`Country`, `e`.`FirstName`, `e`.`ReportsTo`, `e`.`Title`
+FROM `Employees` AS `e`
+WHERE IIF(`e`.`ReportsTo` IS NULL, NULL, CLNG(`e`.`ReportsTo`)) = @__p_0
+""");
         }
 
         public override async Task Where_subquery_closure_via_query_cache(bool isAsync)


### PR DESCRIPTION
Decimal

- Using a decimal with parameters in Odbc hasn't been working in a long time (if ever). Changing its type to Numeric solves the problem
- This might also solve the lanuage/region issues mentioned in #32 

Tried setting my pc to the Polish region with the space as digit grouping separator and had no problems with either OleDb or Odbc. Table is created as follows

![image](https://github.com/bubibubi/EntityFrameworkCore.Jet/assets/18402102/68a96610-fcab-4208-b684-37321cc78de2)

After running the test this is what I see in Access (still in Polish mode)
![image](https://github.com/bubibubi/EntityFrameworkCore.Jet/assets/18402102/3215ee66-d3e4-4a20-8385-135f75589b92)

SQL generated
```
vvv BeginTransaction (Unspecified)==========
ExecuteNonQuery==========
CREATE TABLE `Table` (
    `Id` counter NOT NULL,
    `DecimalValue` decimal(18,2) NOT NULL,
    CONSTRAINT `PK_Table` PRIMARY KEY (`Id`)
)
--- Commit==========

vvv BeginTransaction (Unspecified)==========
ExecuteNonQuery==========
INSERT INTO `Table` (`DecimalValue`)
VALUES (?)
@p0(Decimal) = 1,23
ExecuteDbDataReader==========
SELECT `Id`
FROM `Table`
WHERE @@ROWCOUNT = 1 AND `Id` = @@identity
@@identity = 1
--- Commit==========
ExecuteDbDataReader==========
SELECT `t`.`Id`, `t`.`DecimalValue`
FROM `Table` AS `t`
ExecuteDbDataReader==========
SELECT COUNT(*)
FROM `Table` AS `t`
WHERE `t`.`DecimalValue` = 1.23
```

Bag in Australia English Access switches to show
<img width="313" alt="image" src="https://github.com/bubibubi/EntityFrameworkCore.Jet/assets/18402102/a2fc1256-6d8f-4155-a457-41f69b38ae6c">

and the Insert SQL is

```
ExecuteNonQuery==========
INSERT INTO `Table` (`DecimalValue`)
VALUES (?)
@p0(Decimal) = 1.23
```

Int64

- Int64 gets set up as Odbc or OleDb Type BigInt. In x86 passing this as a parameter is fine (as long as the value is within Int32 limits I assume) as it gets converted. For some reason in x64 it fails to convert (even if the value is '2'. Setting the type to Object seems to bypass this conversion attempt

/cc @lauxjpn